### PR TITLE
Add Microsoft.AspNet.Tooling.Razor dependency to StarterWeb and WebAPI.

### DIFF
--- a/src/StarterWeb/project.json
+++ b/src/StarterWeb/project.json
@@ -14,6 +14,7 @@
         "Microsoft.AspNet.Server.IIS": "1.0.0-beta2-*",
         "Microsoft.AspNet.Server.WebListener": "1.0.0-beta2-*",
         "Microsoft.AspNet.StaticFiles": "1.0.0-beta2-*",
+        "Microsoft.AspNet.Tooling.Razor": "1.0.0-*",
         "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-beta2-*",
         "Microsoft.Framework.CodeGenerators.Mvc": "1.0.0-beta2-*",
         "Microsoft.Framework.Logging": "1.0.0-beta2-*",

--- a/src/WebAPI/project.json
+++ b/src/WebAPI/project.json
@@ -6,7 +6,8 @@
 	"Microsoft.AspNet.Server.IIS": "1.0.0-rc1-*",
 	"Microsoft.AspNet.Mvc": "6.0.0-rc1-*",
         "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-*",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-rc1-*"
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-rc1-*",
+        "Microsoft.AspNet.Tooling.Razor": "1.0.0-*"
     },
     "frameworks": {
         "aspnet50": { },


### PR DESCRIPTION
- Used 1.0.0-\* as the version since it's replaced anyways.
