### PR TITLE
Revert "Use $dnxtargetframeworkversion$ in project.json"

### DIFF
--- a/Templates.Settings.targets
+++ b/Templates.Settings.targets
@@ -49,7 +49,6 @@
         <TemplatesTargetVersionPath>\dev14</TemplatesTargetVersionPath>
         <VersionedReferencePath>Dev14</VersionedReferencePath>
         <TargetVsVersion>VS14</TargetVsVersion>
-        <DnxTargetFrameworkVersion>dnx451</DnxTargetFrameworkVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/BaseTemplates/ClassLibrary/project.json
+++ b/src/BaseTemplates/ClassLibrary/project.json
@@ -14,7 +14,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   }
 }

--- a/src/BaseTemplates/ConsoleApp/project.json
+++ b/src/BaseTemplates/ConsoleApp/project.json
@@ -18,7 +18,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   }
 }

--- a/src/BaseTemplates/EmptyWeb/project.json
+++ b/src/BaseTemplates/EmptyWeb/project.json
@@ -12,7 +12,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   },
 

--- a/src/BaseTemplates/StarterWeb/project.json
+++ b/src/BaseTemplates/StarterWeb/project.json
@@ -21,7 +21,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   },
 

--- a/src/BaseTemplates/WebAPI/project.json
+++ b/src/BaseTemplates/WebAPI/project.json
@@ -14,7 +14,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   },
 

--- a/src/Rules/StarterWeb/AI/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/project.json
@@ -35,7 +35,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   },
 

--- a/src/Rules/StarterWeb/AI/NoAuth/project.json
+++ b/src/Rules/StarterWeb/AI/NoAuth/project.json
@@ -23,7 +23,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   },
 

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/project.json
@@ -27,7 +27,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   },
 

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/project.json
@@ -27,7 +27,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   },
 

--- a/src/Rules/StarterWeb/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/IndividualAuth/project.json
@@ -34,7 +34,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   },
 

--- a/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
@@ -25,7 +25,7 @@
   },
 
   "frameworks": {
-    "$dnxtargetframeworkversion$": { },
+    "dnx451": { },
     "dnxcore50": { }
   },
 

--- a/test/VerifyTemplates.csproj
+++ b/test/VerifyTemplates.csproj
@@ -139,7 +139,6 @@
     <RegexReplace Files="@(ExtractedFiles)" Find="\$guid1\$" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="$(ProjectGuid)" />
     <RegexReplace Files="@(ExtractedFiles)" Find="\$guid2\$" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="$(Guid2)" />
     <RegexReplace Files="@(ExtractedFiles)" Find="\$baseoutputlocation\$" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="src" />
-    <RegexReplace Files="@(ExtractedFiles)" Find="\$dnxtargetframeworkversion\$" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="$(DnxTargetFrameworkVersion)" />
     <RegexReplace Files="@(ExtractedFiles)" Find="Server=\(localdb\)\\\\mssqllocaldb;" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="Server=(localdb)\\templatetests;" />
 
   </Target>
@@ -188,7 +187,6 @@
     <RegexReplace Files="@(ExtractedFiles)" Find="\$guid1\$" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="$(ProjectGuid)" />
     <RegexReplace Files="@(ExtractedFiles)" Find="\$guid2\$" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="$(Guid2)" />
     <RegexReplace Files="@(ExtractedFiles)" Find="\$baseoutputlocation\$" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="src" />
-    <RegexReplace Files="@(ExtractedFiles)" Find="\$dnxtargetframeworkversion\$" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="$(DnxTargetFrameworkVersion)" />
     <RegexReplace Files="@(ExtractedFiles)" Find="Server=\(localdb\)\\\\mssqllocaldb;" Condition="('%(Extension)' == '.json')" Encoding="ascii" Replace="Server=(localdb)\\templatetests;" />
 
     <GetDotNetFolder Condition="'$(DotNetFolder)' == ''">


### PR DESCRIPTION
This reverts commit 251c02b7df23c8de703a20b619ef3dc2149c8d80.

Rolling this back, because the world is broken when user picks 4.5.2 or higher.
