### PR TITLE
Revert "dotnet" framework change in Class Library template.

### DIFF
--- a/src/BaseTemplates/ClassLibrary/project.json
+++ b/src/BaseTemplates/ClassLibrary/project.json
@@ -6,15 +6,16 @@
   "projectUrl": "",
   "licenseUrl": "",
 
-  "dependencies": {
-    "System.Collections": "4.0.11-*",
-    "System.Linq": "4.0.1-*",
-    "System.Threading": "4.0.11-*",
-    "System.Runtime": "4.0.21-*",
-    "Microsoft.CSharp": "4.0.1-*"
-  },
-
   "frameworks": {
-    "dotnet": { }
+    "dnx451": { },
+    "dnxcore50": {
+      "dependencies": {
+        "Microsoft.CSharp": "4.0.1-*",
+        "System.Collections": "4.0.11-*",
+        "System.Linq": "4.0.1-*",
+        "System.Runtime": "4.0.21-*",
+        "System.Threading": "4.0.11-*"
+      }
+    }
   }
 }


### PR DESCRIPTION
We now have dnx451 and dnxcore50 explictly listed again as frameworks.

For issue #144 

@rustd @mayurid @DamianEdwards @davidfowl 
