### PR TITLE
Converted StarterWeb's 'min:js' and 'min:css' Gulp tasks to asynchronous

### DIFF
--- a/src/BaseTemplates/StarterWeb/gulpfile.js
+++ b/src/BaseTemplates/StarterWeb/gulpfile.js
@@ -29,14 +29,14 @@ gulp.task("clean:css", function (cb) {
 gulp.task("clean", ["clean:js", "clean:css"]);
 
 gulp.task("min:js", function () {
-    gulp.src([paths.js, "!" + paths.minJs], { base: "." })
+    return gulp.src([paths.js, "!" + paths.minJs], { base: "." })
         .pipe(concat(paths.concatJsDest))
         .pipe(uglify())
         .pipe(gulp.dest("."));
 });
 
 gulp.task("min:css", function () {
-    gulp.src([paths.css, "!" + paths.minCss])
+    return gulp.src([paths.css, "!" + paths.minCss])
         .pipe(concat(paths.concatCssDest))
         .pipe(cssmin())
         .pipe(gulp.dest("."));


### PR DESCRIPTION
As a best practice, Gulp tasks should return a stream. This has the added benefit of making such tasks asynchronous. See the official Gulp docs here: https://github.com/gulpjs/gulp/blob/master/docs/API.md#return-a-stream.
