### PR TITLE
Addresses #184 remove repeated `btn-default` class

### DIFF
--- a/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
+++ b/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
@@ -16,7 +16,7 @@
                 <div class="carousel-caption">
                     <p>
                         Learn how to build ASP.NET apps that can run anywhere.
-                        <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
+                        <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
                             Learn More
                         </a>
                     </p>
@@ -29,7 +29,7 @@
                 <div class="carousel-caption">
                     <p>
                         There are powerful new features in Visual Studio for building modern web apps.
-                        <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525030&clcid=0x409">
+                        <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525030&clcid=0x409">
                             Learn More
                         </a>
                     </p>
@@ -42,7 +42,7 @@
                 <div class="carousel-caption">
                     <p>
                         Bring in libraries from NuGet, Bower, and npm, and automate tasks using Grunt or Gulp.
-                        <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
+                        <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
                             Learn More
                         </a>
                     </p>
@@ -55,7 +55,7 @@
                 <div class="carousel-caption">
                     <p>
                         Learn how Microsoft's Azure cloud platform allows you to build, deploy, and scale web apps.
-                        <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525027&clcid=0x409">
+                        <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525027&clcid=0x409">
                             Learn More
                         </a>
                     </p>


### PR DESCRIPTION
- Addresses #184 
- removes repeated `btn-default` class from StarterWeb template
