### PR TITLE
Removing SignalR from Project_Readme addresses #195

### DIFF
--- a/src/BaseTemplates/EmptyWeb/Project_Readme.html
+++ b/src/BaseTemplates/EmptyWeb/Project_Readme.html
@@ -176,7 +176,6 @@
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398600">Add Controllers and Views</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398602">Add Data using EntityFramework</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398603">Add Authentication using Identity</a></li>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkID=398606">Add real time support using SignalR</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398604">Add Class library</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkId=518009">Add Web APIs with MVC 6</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=517848">Add client packages using Bower</a></li>

--- a/src/BaseTemplates/StarterWeb/Project_Readme.html
+++ b/src/BaseTemplates/StarterWeb/Project_Readme.html
@@ -176,7 +176,6 @@
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398600">Add Controllers and Views</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398602">Add Data using EntityFramework</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398603">Add Authentication using Identity</a></li>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkID=398606">Add real time support using SignalR</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398604">Add Class library</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkId=518009">Add Web APIs with MVC 6</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=517848">Add client packages using Bower</a></li>

--- a/src/BaseTemplates/WebAPI/Project_Readme.html
+++ b/src/BaseTemplates/WebAPI/Project_Readme.html
@@ -176,7 +176,6 @@
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398600">Add Controllers and Views</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398602">Add Data using EntityFramework</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398603">Add Authentication using Identity</a></li>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkID=398606">Add real time support using SignalR</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=398604">Add Class library</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkId=518009">Add Web APIs with MVC 6</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=517848">Add client packages using Bower</a></li>


### PR DESCRIPTION
Removes SignalR link from Project_Readme.html. Closes #195 
- src/BaseTemplates/EmptyWeb
- src/BaseTemplates/StarterWeb
- src/BaseTemplates/WebAPI
