### PR TITLE
:bug: Use proper names in fallback tests. Fixes #232

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/src/Rules/StarterWeb/IndividualAuth/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -5,10 +5,10 @@
 <environment names="Staging,Production">
     <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"
             asp-fallback-src="~/lib/jquery-validation/jquery.validate.js"
-            asp-fallback-test="window.jquery && window.jquery.validator">
+            asp-fallback-test="window.jQuery && window.jQuery.validator">
     </script>
     <script src="https://ajax.aspnetcdn.com/ajax/mvc/5.2.3/jquery.validate.unobtrusive.min.js"
             asp-fallback-src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"
-            asp-fallback-test="window.jquery && window.jquery.validator && window.jquery.validator.unobtrusive">
+            asp-fallback-test="window.jQuery && window.jQuery.validator && window.jQuery.validator.unobtrusive">
     </script>
 </environment>


### PR DESCRIPTION
- use `jQuery` instead of `jquery` as object name

This commit fixes failing fallback tests for validation
scripts that are failing at runtime due to incorrect name of jQuery object
used in evaluated script. The commit introduces the same notation as used in the
main scripts fallbacks.

Fixes #232 
