### PR TITLE
React to API change in UseDatabaseErrorPage

### DIFF
--- a/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
@@ -93,7 +93,7 @@ namespace $safeprojectname$
             {
                 app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
-                app.UseDatabaseErrorPage(DatabaseErrorPageOptions.ShowAll);
+                app.UseDatabaseErrorPage();
             }
             else
             {

--- a/src/Rules/StarterWeb/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Startup.cs
@@ -83,7 +83,7 @@ namespace $safeprojectname$
             {
                 app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
-                app.UseDatabaseErrorPage(DatabaseErrorPageOptions.ShowAll);
+                app.UseDatabaseErrorPage();
             }
             else
             {


### PR DESCRIPTION
The overload being used in the templates has swapped to a builder pattern (see https://github.com/aspnet/Diagnostics/issues/184). But rather than updating to the new signature, just swapping to the parameterless overload since it enables everything by default (same as UseDeveloperExceptionPage()).
