### PR TITLE
Add text context to toggle buttons

### DIFF
--- a/src/BaseTemplates/StarterWeb/Views/Shared/_Layout.cshtml
+++ b/src/BaseTemplates/StarterWeb/Views/Shared/_Layout.cshtml
@@ -25,6 +25,7 @@
         <div class="container">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="sr-only">Toggle navigation</span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>

--- a/src/Rules/StarterWeb/AI/CommonAuth/Views/Shared/_Layout.cshtml
+++ b/src/Rules/StarterWeb/AI/CommonAuth/Views/Shared/_Layout.cshtml
@@ -26,6 +26,7 @@
             <div class="container">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                        <span class="sr-only">Toggle navigation</span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/src/Rules/StarterWeb/AI/NoAuth/Views/Shared/_Layout.cshtml
+++ b/src/Rules/StarterWeb/AI/NoAuth/Views/Shared/_Layout.cshtml
@@ -26,6 +26,7 @@
             <div class="container">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                        <span class="sr-only">Toggle navigation</span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/src/Rules/StarterWeb/CommonAuth/Views/Shared/_Layout.cshtml
+++ b/src/Rules/StarterWeb/CommonAuth/Views/Shared/_Layout.cshtml
@@ -25,6 +25,7 @@
             <div class="container">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                        <span class="sr-only">Toggle navigation</span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>


### PR DESCRIPTION
This commit adds textual context to _hamburger_ toggle menu
buttons used in navigation. The solution uses built-in Bootstrap
helper class that hides content from page but not from screen readers
and crawlers - .sr-only. The change is future proof as BS 4 alpha seems
to use the same helper class

The markup uses solution documented and used in default Bootstrap 3.\* templates:
http://getbootstrap.com/components/#navbar-default

After the change screen readers are able to see text context of toggle button:

![image](https://cloud.githubusercontent.com/assets/14539/10650943/bf853e26-784c-11e5-87dc-06f547fa0a97.png)

Just a detail.

Thanks!
