### PR TITLE
Enable strict mode in gulpfile.js

### DIFF
--- a/src/BaseTemplates/StarterWeb/gulpfile.js
+++ b/src/BaseTemplates/StarterWeb/gulpfile.js
@@ -1,4 +1,5 @@
 ﻿/// <binding Clean='clean' />
+"use strict";
 
 var gulp = require("gulp"),
     rimraf = require("rimraf"),


### PR DESCRIPTION
I enabled strict mode in gulpfile.js. This will prevent developers from doing potentially harmful things in the file, such as using JavaScript "with" blocks.
