### PR TITLE
Define gulpfile.js asset paths in more terse manner

### DIFF
--- a/src/BaseTemplates/StarterWeb/gulpfile.js
+++ b/src/BaseTemplates/StarterWeb/gulpfile.js
@@ -7,16 +7,16 @@ var gulp = require("gulp"),
     cssmin = require("gulp-cssmin"),
     uglify = require("gulp-uglify");
 
-var paths = {
-    webroot: "./wwwroot/"
-};
+var webroot = "./wwwroot/";
 
-paths.js = paths.webroot + "js/**/*.js";
-paths.minJs = paths.webroot + "js/**/*.min.js";
-paths.css = paths.webroot + "css/**/*.css";
-paths.minCss = paths.webroot + "css/**/*.min.css";
-paths.concatJsDest = paths.webroot + "js/site.min.js";
-paths.concatCssDest = paths.webroot + "css/site.min.css";
+var paths = {
+    js: webroot + "js/**/*.js",
+    minJs: webroot + "js/**/*.min.js",
+    css: webroot + "css/**/*.css",
+    minCss: webroot + "css/**/*.min.css",
+    concatJsDest: webroot + "js/site.min.js",
+    concatCssDest: webroot + "css/site.min.css"
+};
 
 gulp.task("clean:js", function (cb) {
     rimraf(paths.concatJsDest, cb);


### PR DESCRIPTION
The file paths defined in the gulpfile.js file can be defined in a more concise fashion, so that `paths.` doesn't have to be keyed over and over again when adding new properties to the `paths` object literal.
