### PR TITLE
Add Gulp watch task for JS and CSS minification

### DIFF
--- a/src/BaseTemplates/StarterWeb/gulpfile.js
+++ b/src/BaseTemplates/StarterWeb/gulpfile.js
@@ -1,4 +1,4 @@
-﻿/// <binding Clean='clean' />
+﻿/// <binding Clean='clean' ProjectOpened='watch' />
 "use strict";
 
 var gulp = require("gulp"),
@@ -43,3 +43,8 @@ gulp.task("min:css", function () {
 });
 
 gulp.task("min", ["min:js", "min:css"]);
+
+gulp.task("watch", function () {
+    gulp.watch([paths.css, "!" + paths.minCss], ["min:css"]);
+    gulp.watch([paths.js, "!" + paths.minJs], ["min:js"]);
+});


### PR DESCRIPTION
This PR addresses issue #274 by adding a new "watch" task to `gulpfile.js`. With this enhancement in place, JavaScript and CSS files matching the file globs will be minified both upon opening the project and upon saving the files. This eliminates the need to manually run the tasks via Task Runner Explorer (VS) or Command Palette (VS Code).
