### PR TITLE
Align `build.cmd` with latest Universe templates

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,8 +1,11 @@
-@echo off 
+@echo off
 cd %~dp0
 
 SETLOCAL
-SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
+SET NUGET_VERSION=latest
+SET CACHED_NUGET=%LocalAppData%\NuGet\nuget.%NUGET_VERSION%.exe
+SET BUILDCMD_KOREBUILD_VERSION=
+SET BUILDCMD_DNX_VERSION=
 
 IF "%*"=="" (
   SET SCRIPTARGS=verify
@@ -10,25 +13,34 @@ IF "%*"=="" (
   SET SCRIPTARGS=%*
 )
 
-IF EXIST %CACHED_NUGET% goto copynuget 
-echo Downloading latest version of NuGet.exe... 
-IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet 
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'" 
- 
-:copynuget 
-IF EXIST .nuget\nuget.exe goto restore 
-md .nuget 
-copy %CACHED_NUGET% .nuget\nuget.exe > nul 
- 
-:restore 
-IF EXIST packages\KoreBuild goto run  
-.nuget\NuGet.exe install KoreBuild -ExcludeVersion -o packages -nocache -pre -Source https://myget.org/F/aspnetvnext
+IF EXIST %CACHED_NUGET% goto copynuget
+echo Downloading latest version of NuGet.exe...
+IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/%NUGET_VERSION%/nuget.exe' -OutFile '%CACHED_NUGET%'"
+
+:copynuget
+IF EXIST .nuget\nuget.exe goto restore
+md .nuget
+copy %CACHED_NUGET% .nuget\nuget.exe > nul
+
+:restore
+IF EXIST packages\Sake goto getdnx
+IF "%BUILDCMD_KOREBUILD_VERSION%"=="" (
+    .nuget\nuget.exe install KoreBuild -ExcludeVersion -o packages -nocache -pre
+) ELSE (
+    .nuget\nuget.exe install KoreBuild -version %BUILDCMD_KOREBUILD_VERSION% -ExcludeVersion -o packages -nocache -pre
+)
 .nuget\NuGet.exe install Sake -ExcludeVersion -Source https://www.nuget.org/api/v2/ -Out packages
- 
-IF "%SKIP_DNX_INSTALL%"=="1" goto run 
-CALL packages\KoreBuild\build\dnvm upgrade -runtime CLR -arch x86 
-CALL packages\KoreBuild\build\dnvm install default -runtime CoreCLR -arch x86 
- 
-:run 
-CALL packages\KoreBuild\build\dnvm use default -runtime CLR -arch x86
+
+:getdnx
+IF "%BUILDCMD_DNX_VERSION%"=="" (
+    SET BUILDCMD_DNX_VERSION=latest
+)
+IF "%SKIP_DNX_INSTALL%"=="" (
+    CALL packages\KoreBuild\build\dnvm install %BUILDCMD_DNX_VERSION% -runtime CoreCLR -arch x86 -alias default
+    CALL packages\KoreBuild\build\dnvm install default -runtime CLR -arch x86 -alias default
+) ELSE (
+    CALL packages\KoreBuild\build\dnvm use default -runtime CLR -arch x86
+)
+
 CALL tools\BuildAndVerify.cmd /t:%SCRIPTARGS%


### PR DESCRIPTION
- use latest `NuGet.exe`
- use specified (often prerelease) KoreBuild package
- avoid `dnvm upgrade` because it messes with the user-level `$env:Path` setting

nit: remove trailing whitespace
