### PR TITLE
React to aspnet/Razor#561.

### DIFF
--- a/src/BaseTemplates/StarterWeb/Views/_ViewImports.cshtml
+++ b/src/BaseTemplates/StarterWeb/Views/_ViewImports.cshtml
@@ -1,2 +1,2 @@
 ﻿@using $safeprojectname$
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers

--- a/src/Rules/StarterWeb/AI/CommonAuth/Views/_ViewImports.cshtml
+++ b/src/Rules/StarterWeb/AI/CommonAuth/Views/_ViewImports.cshtml
@@ -1,4 +1,4 @@
 ﻿@using $safeprojectname$
 @using Microsoft.Extensions.OptionsModel
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers
 @inject Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration TelemetryConfiguration

--- a/src/Rules/StarterWeb/AI/IndividualAuth/Views/_ViewImports.cshtml
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/Views/_ViewImports.cshtml
@@ -3,5 +3,5 @@
 @using $safeprojectname$.ViewModels.Account
 @using $safeprojectname$.ViewModels.Manage
 @using Microsoft.AspNet.Identity
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers
 @inject Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration TelemetryConfiguration

--- a/src/Rules/StarterWeb/AI/NoAuth/Views/_ViewImports.cshtml
+++ b/src/Rules/StarterWeb/AI/NoAuth/Views/_ViewImports.cshtml
@@ -1,4 +1,4 @@
 ﻿@using $safeprojectname$
 @using Microsoft.Extensions.OptionsModel
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers
 @inject Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration TelemetryConfiguration

--- a/src/Rules/StarterWeb/IndividualAuth/Views/_ViewImports.cshtml
+++ b/src/Rules/StarterWeb/IndividualAuth/Views/_ViewImports.cshtml
@@ -3,4 +3,4 @@
 @using $safeprojectname$.ViewModels.Account
 @using $safeprojectname$.ViewModels.Manage
 @using Microsoft.AspNet.Identity
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers


### PR DESCRIPTION
- `TagHelper` directives no longer have quotes.
