### PR TITLE
remove unnecessary usages of await

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
@@ -466,9 +466,9 @@ namespace $safeprojectname$.Controllers
             }
         }
 
-        private async Task<ApplicationUser> GetCurrentUserAsync()
+        private Task<ApplicationUser> GetCurrentUserAsync()
         {
-            return await _userManager.FindByIdAsync(HttpContext.User.GetUserId());
+            return _userManager.FindByIdAsync(HttpContext.User.GetUserId());
         }
 
         private IActionResult RedirectToLocal(string returnUrl)

--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/ManageController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/ManageController.cs
@@ -337,9 +337,9 @@ namespace $safeprojectname$.Controllers
             Error
         }
 
-        private async Task<ApplicationUser> GetCurrentUserAsync()
+        private Task<ApplicationUser> GetCurrentUserAsync()
         {
-            return await _userManager.FindByIdAsync(HttpContext.User.GetUserId());
+            return _userManager.FindByIdAsync(HttpContext.User.GetUserId());
         }
 
         #endregion


### PR DESCRIPTION
awaiting a return of a task object is unnecessary
