### PR TITLE
Add runtime.any* to fix package closure for templates/Browserlink

### DIFF
--- a/TemplatePackages.txt
+++ b/TemplatePackages.txt
@@ -7,6 +7,7 @@
 +dnx-clr-win-*
 +dnx-coreclr-win-*
 +runtime.win*
++runtime.any*
 +Microsoft.AspNet.Authentication.OAuthBearer.*
 +Microsoft.AspNet.Diagnostics.Elm.*
 +Microsoft.AspNet.Mvc.WebApiCompatShim.*


### PR DESCRIPTION
This fixes a closure issue with RC1 packages. BrowserLink has an indirect dependency on runtime.any.System.Linq.Expressions.4.0.11-beta-23509.nupkg
