### PR TITLE
Remove duplicate declarations for .carousel-caption class

### DIFF
--- a/src/BaseTemplates/StarterWeb/wwwroot/css/site.css
+++ b/src/BaseTemplates/StarterWeb/wwwroot/css/site.css
@@ -18,17 +18,7 @@ textarea {
 }
 
 /* Carousel */
-.carousel-caption {
-    z-index: 10 !important;
-}
-
     .carousel-caption p {
         font-size: 20px;
         line-height: 1.4;
     }
-
-@media (min-width: 768px) {
-    .carousel-caption {
-        z-index: 10 !important;
-    }
-}

--- a/src/BaseTemplates/StarterWeb/wwwroot/css/site.min.css
+++ b/src/BaseTemplates/StarterWeb/wwwroot/css/site.min.css
@@ -1,1 +1,1 @@
-﻿body{padding-top:50px;padding-bottom:20px}.body-content{padding-left:15px;padding-right:15px}input,select,textarea{max-width:280px}.carousel-caption{z-index:10!important}.carousel-caption p{font-size:20px;line-height:1.4}@media (min-width:768px){.carousel-caption{z-index:10!important}}
+﻿body{padding-top:50px;padding-bottom:20px}.body-content{padding-left:15px;padding-right:15px}input,select,textarea{max-width:280px}.carousel-caption p{font-size:20px;line-height:1.4}


### PR DESCRIPTION
The z-index property is already declared in original Bootstrap CSS:

``` css
.carousel-caption {
  position: absolute;
  ...
  bottom: 20px;
  z-index: 10;
  padding-top: 20px;
  ...
```

http://git.io/v4GRF
The duplicated declarations are only adding noise to source code
of templates - which are supposed to be used as guides (why someone
should start to wonder what is a purpose of these z-index declarations?)

Thanks!
