### PR TITLE
Use expression bodied member in HomeController Error method

### DIFF
--- a/src/BaseTemplates/StarterWeb/Controllers/HomeController.cs
+++ b/src/BaseTemplates/StarterWeb/Controllers/HomeController.cs
@@ -27,9 +27,6 @@ namespace $safeprojectname$.Controllers
             return View();
         }
 
-        public IActionResult Error()
-        {
-            return View();
-        }
+        public IActionResult Error() => View();
     }
 }


### PR DESCRIPTION
I modified the StarterWeb project's HomeController Error action method to use a C# expression bodied member. My experience has been that this action method rarely deviates from the default template code, making it a perfect fit for this new C# feature. I considered doing the same for the Index action method; however, that method does often consist of much more than a return statement.

See [this issue](https://github.com/aspnet/Templates/issues/316) for the discussion leading up to this PR.
