### PR TITLE
Update Web API route comment to enforce consistency

### DIFF
--- a/src/BaseTemplates/WebAPI/Controllers/ValuesController.cs
+++ b/src/BaseTemplates/WebAPI/Controllers/ValuesController.cs
@@ -9,7 +9,7 @@ namespace $safeprojectname$.Controllers
     [Route("api/[controller]")]
     public class ValuesController : Controller
     {
-        // GET: api/values
+        // GET api/values
         [HttpGet]
         public IEnumerable<string> Get()
         {


### PR DESCRIPTION
The very first method in the `ValuesController.cs` file uses a colon in the comment. This is inconsistent with how the comments are formatted downstream in the same file. This PR removes the colon to enforce consistency.
