### PR TITLE
:bug: Add style to hide captions on small screens

### DIFF
--- a/src/BaseTemplates/StarterWeb/wwwroot/css/site.css
+++ b/src/BaseTemplates/StarterWeb/wwwroot/css/site.css
@@ -22,3 +22,10 @@ textarea {
     font-size: 20px;
     line-height: 1.4;
 }
+/* Hide/rearrange for smaller screens */
+@media screen and (max-width: 767px) {
+  /* Hide captions */
+  .carousel-caption {
+    display: none
+  }
+}

--- a/src/BaseTemplates/StarterWeb/wwwroot/css/site.min.css
+++ b/src/BaseTemplates/StarterWeb/wwwroot/css/site.min.css
@@ -1,1 +1,1 @@
-﻿body{padding-top:50px;padding-bottom:20px}.body-content{padding-left:15px;padding-right:15px}input,select,textarea{max-width:280px}.carousel-caption p{font-size:20px;line-height:1.4}
+body{padding-top:50px;padding-bottom:20px}.body-content{padding-left:15px;padding-right:15px}input,select,textarea{max-width:280px}.carousel-caption p{font-size:20px;line-height:1.4}@media screen and (max-width:767px){.carousel-caption{display:none}}


### PR DESCRIPTION
Related issue: #327

This commit re-introduce a rule for .carousel-caption available
with recently removed BS Carousel Touch library:
http://git.io/v4h9l
The change will fix rendering of carousel content under small
screens until better solution is provided.

The page before fix as reported:

![https://cloud.githubusercontent.com/assets/15947066/11308164/dc6b3c72-8f79-11e5-90bc-35385476cb9d.png](https://cloud.githubusercontent.com/assets/15947066/11308164/dc6b3c72-8f79-11e5-90bc-35385476cb9d.png)

The page after fix:
![20151121173807](https://cloud.githubusercontent.com/assets/14539/11319603/d9308554-907c-11e5-9a2a-a214ea4951f2.jpg)

Thanks!
