### PR TITLE
:bug: Fix negative offset of checkbox component

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Views/Account/Login.cshtml
+++ b/src/Rules/StarterWeb/IndividualAuth/Views/Account/Login.cshtml
@@ -33,8 +33,10 @@
                 <div class="form-group">
                     <div class="col-md-offset-2 col-md-10">
                         <div class="checkbox">
-                            <input asp-for="RememberMe" />
-                            <label asp-for="RememberMe"></label>
+                            <label asp-for="RememberMe">
+                                <input asp-for="RememberMe" />
+                                @Html.DisplayNameFor(m => m.RememberMe)
+                            </label>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Related issue: #327 

This commit fixes negative offset of checkbox BS component
under BS 3.3.5 - which is now used in aspnet/Templates.
The checkbox component under 3.3.5 requires specific markup -
which at this time is not possible to render correctly with
MVC Razor tag helpers: http://git.io/v4h5M
The fix uses purpose written markup to overcome rendering
problem

The other solution to the problem is to write custom CSS rules to fix rendering problem under BS 3.3.5.
Both solutions have different drawbacks in terms of documenting platform via templates.

I've chosen custom markup as solution, as it could introduce people to some topics in MVC/Razor and because it is not hidden in CSS.

Rendered html markup:

``` html
<div class="checkbox">
    <label for="RememberMe">
        <input data-val="true" data-val-required="The Remember me? field is required." id="RememberMe" name="RememberMe" type="checkbox" value="true">
        Remember me?
    </label>
</div>
```

Thanks!
