### PR TITLE
Fix typo wrong methode FindByNameAsync=>FindByEmailAsync

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
@@ -310,7 +310,7 @@ namespace $safeprojectname$.Controllers
             {
                 return View(model);
             }
-            var user = await _userManager.FindByNameAsync(model.Email);
+            var user = await _userManager.FindByEmailAsync(model.Email);
             if (user == null)
             {
                 // Don't reveal that the user does not exist

--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
@@ -261,7 +261,7 @@ namespace $safeprojectname$.Controllers
         {
             if (ModelState.IsValid)
             {
-                var user = await _userManager.FindByNameAsync(model.Email);
+                var user = await _userManager.FindByEmailAsync(model.Email);
                 if (user == null || !(await _userManager.IsEmailConfirmedAsync(user)))
                 {
                     // Don't reveal that the user does not exist or is not confirmed


### PR DESCRIPTION
@rustd I found that the wrong method was use for finding an email address
