### PR TITLE
Fix style.css file selector indentation

### DIFF
--- a/src/BaseTemplates/StarterWeb/wwwroot/css/site.css
+++ b/src/BaseTemplates/StarterWeb/wwwroot/css/site.css
@@ -18,7 +18,7 @@ textarea {
 }
 
 /* Carousel */
-    .carousel-caption p {
-        font-size: 20px;
-        line-height: 1.4;
-    }
+.carousel-caption p {
+    font-size: 20px;
+    line-height: 1.4;
+}


### PR DESCRIPTION
This small commit fixes a selector declaration indentation,
preventing from propagating to next lines - which is
most IDE/editors default behavior
Thanks!
