### PR TITLE
:art: Two small fixes to landing page carousel

### DIFF
--- a/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
+++ b/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
@@ -13,8 +13,10 @@
         <div class="item active">
             <img src="~/images/ASP-NET-Banners-01.png" alt="ASP.NET" class="img-responsive" />
             <div class="carousel-caption">
-                <p>
+                <p class="hidden-xs hidden-sm">
                     Learn how to build ASP.NET apps that can run anywhere.
+                </p>
+                <p>
                     <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
                         Learn More
                     </a>
@@ -24,8 +26,10 @@
         <div class="item">
             <img src="~/images/Banner-02-VS.png" alt="Visual Studio" class="img-responsive" />
             <div class="carousel-caption">
-                <p>
+                <p class="hidden-xs hidden-sm">
                     There are powerful new features in Visual Studio for building modern web apps.
+                </p>
+                <p>
                     <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525030&clcid=0x409">
                         Learn More
                     </a>
@@ -35,8 +39,10 @@
         <div class="item">
             <img src="~/images/ASP-NET-Banners-02.png" alt="Package Management" class="img-responsive" />
             <div class="carousel-caption">
-                <p>
+                <p class="hidden-xs hidden-sm">
                     Bring in libraries from NuGet, Bower, and npm, and automate tasks using Grunt or Gulp.
+                </p>
+                <p>
                     <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
                         Learn More
                     </a>
@@ -46,8 +52,10 @@
         <div class="item">
             <img src="~/images/Banner-01-Azure.png" alt="Microsoft Azure" class="img-responsive" />
             <div class="carousel-caption">
-                <p>
+                <p class="hidden-xs hidden-sm">
                     Learn how Microsoft's Azure cloud platform allows you to build, deploy, and scale web apps.
+                </p>
+                <p>
                     <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525027&clcid=0x409">
                         Learn More
                     </a>


### PR DESCRIPTION
This commit introduces two different fixes to home page
carousel component layout:
- the interactive elements are wrapped into paragraph tag and
  are now displayed in separate row in a block
- the carousel caption paragraphs are now hidden on small
  screens
  This changes are quick and do not require changes in CSS style.
  They should be changed in the future when content design will be
  under review

The > 768 and < 768 screens after this changes:

![20151124221435](https://cloud.githubusercontent.com/assets/14539/11381009/d3c0a58e-92f9-11e5-8194-c2be8dcadba3.jpg)

![20151124221407](https://cloud.githubusercontent.com/assets/14539/11381050/064bd712-92fa-11e5-9334-9c09ef0aa4a4.jpg)

Note: that is somehow obvious that design was not mobile-first when first created. The small screens landing page needs some love (the content should be higher and with different background images for carousel (example comes with image set via `object-fit: fill`, so the content is distorted):

![image](https://cloud.githubusercontent.com/assets/14539/11381195/fb550bca-92fa-11e5-97d0-f76c0f1d21e8.png)

For related subject and  discussion, please see:
https://github.com/aspnet/Templates/pull/336#issuecomment-159356581

Thanks!
