### PR TITLE
Fix appsetting documentation in StarterWeb template

### DIFF
--- a/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
+++ b/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
@@ -78,7 +78,7 @@
         <h2>How to</h2>
         <ul>
             <li><a href="http://go.microsoft.com/fwlink/?LinkID=398600">Add a Controller and View</a></li>
-            <li><a href="http://go.microsoft.com/fwlink/?LinkID=699314">Add an appsetting in config and access it in app.</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=699562">Add an appsetting in config and access it in app.</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=699315">Manage User Secrets using Secret Manager.</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=699316">Use logging to log a message.</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=699317">Add packages using NuGet.</a></li>


### PR DESCRIPTION
Previously redirecting to MS home page.
Now points to correct redirect.
