### PR TITLE
Remove asterisk from bootstrap folder reference in .csproj file

### DIFF
--- a/src/BaseTemplates/BaseProjectTemplates.csproj
+++ b/src/BaseTemplates/BaseProjectTemplates.csproj
@@ -102,7 +102,7 @@
       <FilesToVerify Remove="**\*.min.css"/>
       <FilesToVerify Remove="StarterWeb\node_modules\**\*.*"/>
       <FilesToVerify Remove="StarterWeb\bower_components\**\*.*"/>
-      <FilesToVerify Remove="StarterWeb\wwwroot\lib\bootstrap*\**\*.*"/>
+      <FilesToVerify Remove="StarterWeb\wwwroot\lib\bootstrap\**\*.*"/>
       <FilesToVerify Remove="StarterWeb\wwwroot\lib\jquery*\**\*.*"/>
       <FilesToVerify Remove="StarterWeb\wwwroot\lib\**\*.*"/>
       <FilesToVerify Remove="StarterWeb\wwwroot\images\**\*.*"/>


### PR DESCRIPTION
The single asterisk following the `StarterWeb\wwwroot\lib\bootstrap` folder path reference in `BaseProjectTemplates.csproj` appears to be unnecessary. I suspect this was only there to support the presence of "bootstrap-touch-carousel", which has been removed from the templates.
