### PR TITLE
Unify conventions of using built-in Configuration providers in templates

### DIFF
--- a/src/BaseTemplates/StarterWeb/Startup.cs
+++ b/src/BaseTemplates/StarterWeb/Startup.cs
@@ -17,6 +17,7 @@ namespace $safeprojectname$
             // Set up configuration sources.
             var builder = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
             Configuration = builder.Build();
         }

--- a/src/BaseTemplates/WebAPI/Startup.cs
+++ b/src/BaseTemplates/WebAPI/Startup.cs
@@ -17,6 +17,7 @@ namespace $safeprojectname$
             // Set up configuration sources.
             var builder = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
             Configuration = builder.Build();
         }

--- a/src/Rules/StarterWeb/AI/NoAuth/Startup.cs
+++ b/src/Rules/StarterWeb/AI/NoAuth/Startup.cs
@@ -17,6 +17,7 @@ namespace $safeprojectname$
             // Set up configuration sources.
             var builder = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
 
             if (env.IsDevelopment())

--- a/src/Rules/WebAPI/AI/NoAuth/Startup.cs
+++ b/src/Rules/WebAPI/AI/NoAuth/Startup.cs
@@ -17,6 +17,7 @@ namespace $safeprojectname$
             // Set up configuration sources.
             var builder = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json");
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
 
             if (env.IsEnvironment("Development"))
             {
@@ -25,7 +26,7 @@ namespace $safeprojectname$
             }
 
             builder.AddEnvironmentVariables();
-            Configuration = builder.Build().ReloadOnChanged("appsettings.json");
+            Configuration = builder.Build();
         }
 
         public IConfigurationRoot Configuration { get; set; }


### PR DESCRIPTION
Closes #350 

@rustd @joeloff 

All:
                .AddJsonFile("appsettings.json");
                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
                 .AddEnvironmentVariables(); (this is always last, even after the ones that are below)

+Any Auth (Development env only):
                .AddUserSecrets

+AI (Development env only):
                 .AddApplicationInsightsSettings(developerMode: true);

I've also removed an extraneous ReloadOnChanged call in the WebAPI template which was not reverted. 
