### PR TITLE
Add .npmrc to DnxInvisibleContent item group

### DIFF
--- a/src/BaseTemplates/EmptyWeb/EmptyWeb.xproj
+++ b/src/BaseTemplates/EmptyWeb/EmptyWeb.xproj
@@ -20,6 +20,7 @@
     <DnxInvisibleContent Include="bower.json" />
     <DnxInvisibleContent Include=".bowerrc" />
     <DnxInvisibleContent Include="package.json" />
+    <DnxInvisibleContent Include=".npmrc" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/BaseTemplates/StarterWeb/StarterWeb.xproj
+++ b/src/BaseTemplates/StarterWeb/StarterWeb.xproj
@@ -18,6 +18,7 @@
     <DnxInvisibleContent Include="bower.json" />
     <DnxInvisibleContent Include=".bowerrc" />
     <DnxInvisibleContent Include="package.json" />
+    <DnxInvisibleContent Include=".npmrc" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
The `DnxInvisibleContent` item group which was added to the project file (per issue https://github.com/aspnet/Templates/issues/168) didn't take into consideration the scenario when the developer adds a `.npmrc` file to the project. This PR adds this file to the item group. The thought is that the `.npmrc` file will receive the same treatment as the `.bowerrc` file. In my opinion, it looks odd when the `.npmrc` file is visible in Solution Explorer but the `package.json` file is invisible. These 2 npm artifacts should receive the same visibility treatment, as is the case with the 2 Bower artifacts.
