### PR TITLE
Explicitly set package.json private property to true

### DIFF
--- a/src/BaseTemplates/StarterWeb/package.json
+++ b/src/BaseTemplates/StarterWeb/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ASP.NET",
   "version": "0.0.0",
+  "private": true,
   "devDependencies": {
     "gulp": "3.8.11",
     "gulp-concat": "2.5.2",


### PR DESCRIPTION
The `package.json` file included in the "StarterWeb" template is inconsistent with the "NPM Configuration File" item template in that it doesn't set the `private` property. In addition to enforcing consistency between the item and project templates, explicitly setting this property to `true` prevents accidental publication to the npm registry. My guess is that this is most developers' desired behavior the majority of the time. 
