### PR TITLE
Alter package.json name value to meet specification

### DIFF
--- a/src/BaseTemplates/StarterWeb/package.json
+++ b/src/BaseTemplates/StarterWeb/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ASP.NET",
+  "name": "asp.net",
   "version": "0.0.0",
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
This PR addresses issue https://github.com/aspnet/Templates/issues/369. By changing the `name` property value to all lowercase, npm's specification is met.

Note that the "NPM Configuration File" item template suffers from the same problems and should be updated too.
