### PR TITLE
Use resources from the dotnet package

### DIFF
--- a/src/BaseTemplates/ClassLibrary.vstemplate
+++ b/src/BaseTemplates/ClassLibrary.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5005"/>
-    <Description Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5006"/>
+    <Name Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5005"/>
+    <Description Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5006"/>
     <Icon>LibraryProject.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/ConsoleApp.vstemplate
+++ b/src/BaseTemplates/ConsoleApp.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5007"/>
-    <Description Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5008"/>
+    <Name Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5007"/>
+    <Description Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5008"/>
     <Icon>ConsoleProject.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>


### PR DESCRIPTION
The Class Library (.NET Core) and Console App (.NET Core) vstemplates
should load their resources from the dotnet VS package so that the correct
text is displayed even if WTE aren't installed.
