### PR TITLE
Point the correct vstemplates at the dotnet package

### DIFF
--- a/src/BaseTemplates/ClassLibrary.vstemplate
+++ b/src/BaseTemplates/ClassLibrary.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5005"/>
-    <Description Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5006"/>
+    <Name Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5005"/>
+    <Description Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5006"/>
     <Icon>LibraryProject.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/ConsoleApp.vstemplate
+++ b/src/BaseTemplates/ConsoleApp.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5007"/>
-    <Description Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5008"/>
+    <Name Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5007"/>
+    <Description Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5008"/>
     <Icon>ConsoleProject.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/DNXClassLibrary.vstemplate
+++ b/src/BaseTemplates/DNXClassLibrary.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5009"/>
-    <Description Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5010"/>
+    <Name Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5009"/>
+    <Description Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5010"/>
     <Icon>LibraryProject.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/DNXConsoleApp.vstemplate
+++ b/src/BaseTemplates/DNXConsoleApp.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5011"/>
-    <Description Package="{AAB75614-2F8F-4DA6-B0A6-763C6DBB2969}" ID="5012"/>
+    <Name Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5011"/>
+    <Description Package="{98f77210-a364-4168-bae6-4d46fa7e19fe}" ID="5012"/>
     <Icon>ConsoleProject.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>


### PR DESCRIPTION
I changed "classlibrary.vstemplate" and "consoleapp.vstemplate" to reference the dotnet package when I should have changed "dnxclasslibrary.vstemplate" and "dnxconsoleapp.vstemplate". The dnx*.vstemplates are actually ones that are dropped under .NET Core.
