### PR TITLE
Update OutputPath in xproj files.

### DIFF
--- a/src/BaseTemplates/ClassLibrary/ClassLibrary.xproj
+++ b/src/BaseTemplates/ClassLibrary/ClassLibrary.xproj
@@ -10,7 +10,7 @@
     <ProjectGuid>$guid1$</ProjectGuid>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$baseoutputlocation$\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\</OutputPath>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
   </PropertyGroup>
 

--- a/src/BaseTemplates/ConsoleApp/ConsoleApp.xproj
+++ b/src/BaseTemplates/ConsoleApp/ConsoleApp.xproj
@@ -10,7 +10,7 @@
     <ProjectGuid>$guid1$</ProjectGuid>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$baseoutputlocation$\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\</OutputPath>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
   </PropertyGroup>
 

--- a/src/BaseTemplates/EmptyWeb/EmptyWeb.xproj
+++ b/src/BaseTemplates/EmptyWeb/EmptyWeb.xproj
@@ -10,7 +10,7 @@
     <ProjectGuid>$guid1$</ProjectGuid>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$baseoutputlocation$\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\</OutputPath>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
   </PropertyGroup>
 

--- a/src/BaseTemplates/StarterWeb/StarterWeb.xproj
+++ b/src/BaseTemplates/StarterWeb/StarterWeb.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>$guid1$</ProjectGuid>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$baseoutputlocation$\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\</OutputPath>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/BaseTemplates/WebAPI/WebAPI.xproj
+++ b/src/BaseTemplates/WebAPI/WebAPI.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>$guid1$</ProjectGuid>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$baseoutputlocation$\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$baseoutputlocation$\</OutputPath>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Dotnet already adds the project directory, configuration, rid and tfm to whatever base path we set.. We can leave the intermediate output directory alone.

@BillHiebert 
