### PR TITLE
Update .NET Core templates

### DIFF
--- a/src/BaseTemplates/ClassLibrary/project.json
+++ b/src/BaseTemplates/ClassLibrary/project.json
@@ -2,10 +2,10 @@
     "version": "1.0.0-*",
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23810"
+        "NETStandard.Library": "1.0.0-rc2-23830"
     },
 
     "frameworks": {
-        "dotnet5.5": { }
+        "netstandard1.5": { }
     }
 }

--- a/src/BaseTemplates/ConsoleApp/project.json
+++ b/src/BaseTemplates/ConsoleApp/project.json
@@ -5,10 +5,10 @@
     },
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23810"
+        "NETStandard.Library": "1.0.0-rc2-23830"
     },
 
     "frameworks": {
-        "dnxcore50": { }
+        "netstandardapp1.5": { }
     }
 }


### PR DESCRIPTION
Use netstandard TFMs
Update to most recent package build, which allows exclusion of imports statements.
