### PR TITLE
Add UseForwardedHeaders to templates

### DIFF
--- a/src/BaseTemplates/EmptyWeb/Startup.cs
+++ b/src/BaseTemplates/EmptyWeb/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,8 +23,13 @@ namespace $safeprojectname$
         {$if$ ($aspnet_useplatformhandler$ == false)
 $else$
             app.UseIISPlatformHandler();
+$endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
 
-$endif$            app.Run(async (context) =>
+            app.Run(async (context) =>
             {
                 await context.Response.WriteAsync("Hello World!");
             });

--- a/src/BaseTemplates/EmptyWeb/project.json
+++ b/src/BaseTemplates/EmptyWeb/project.json
@@ -5,10 +5,10 @@
     "preserveCompilationContext": true
   },
 
-  "dependencies": {$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",$else$
+  "dependencies": {
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "NETStandard.Library": "1.0.0-*"
   },
 

--- a/src/BaseTemplates/StarterWeb/Startup.cs
+++ b/src/BaseTemplates/StarterWeb/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -37,12 +38,14 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
 
             if (env.IsDevelopment())
             {

--- a/src/BaseTemplates/StarterWeb/project.json
+++ b/src/BaseTemplates/StarterWeb/project.json
@@ -6,10 +6,10 @@
   },
 
   "dependencies": {
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",

--- a/src/BaseTemplates/WebAPI/Startup.cs
+++ b/src/BaseTemplates/WebAPI/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -37,12 +38,15 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
+
             app.UseMvc();
         }
     }

--- a/src/BaseTemplates/WebAPI/project.json
+++ b/src/BaseTemplates/WebAPI/project.json
@@ -5,10 +5,10 @@
     "preserveCompilationContext": true
   },
 
-  "dependencies": {$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+  "dependencies": {
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.Extensions.Configuration.FileProviderExtensions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -68,12 +69,14 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
 
             app.UseApplicationInsightsRequestTelemetry();
 

--- a/src/Rules/StarterWeb/AI/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/project.json
@@ -10,11 +10,11 @@
     "Microsoft.ApplicationInsights.AspNet": "__ApplicationInsightsPackageVersion__",
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.Identity": "1.0.0-*",
-    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",

--- a/src/Rules/StarterWeb/AI/NoAuth/Startup.cs
+++ b/src/Rules/StarterWeb/AI/NoAuth/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -45,12 +46,14 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
 
             app.UseApplicationInsightsRequestTelemetry();
 

--- a/src/Rules/StarterWeb/AI/NoAuth/project.json
+++ b/src/Rules/StarterWeb/AI/NoAuth/project.json
@@ -7,10 +7,10 @@
 
   "dependencies": {
     "Microsoft.ApplicationInsights.AspNet": "__ApplicationInsightsPackageVersion__",
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/Startup.cs
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/Startup.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -50,12 +51,14 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
 
             app.UseApplicationInsightsRequestTelemetry();
 

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/project.json
@@ -10,10 +10,10 @@
     "Microsoft.ApplicationInsights.AspNet": "__ApplicationInsightsPackageVersion__",
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "0.1.0-*",
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/Startup.cs
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/Startup.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -49,12 +50,14 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
 
             app.UseApplicationInsightsRequestTelemetry();
 

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/project.json
@@ -10,10 +10,10 @@
     "Microsoft.ApplicationInsights.AspNet": "__ApplicationInsightsPackageVersion__",
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "0.1.0-*",
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",

--- a/src/Rules/StarterWeb/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -62,12 +63,14 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/IndividualAuth/project.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.Identity": "1.0.0-*",
-    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",

--- a/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
@@ -9,10 +9,10 @@
   "dependencies": {
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "0.1.0-*",
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",

--- a/src/Rules/StarterWeb/OrganizationalAuth/Multiple/Startup.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Multiple/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -46,12 +47,14 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/OrganizationalAuth/Single/Startup.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Single/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -45,12 +46,14 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/WebAPI/AI/NoAuth/Startup.cs
+++ b/src/Rules/WebAPI/AI/NoAuth/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -46,12 +47,15 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
+
             app.UseApplicationInsightsRequestTelemetry();
 
             app.UseApplicationInsightsExceptionTelemetry();

--- a/src/Rules/WebAPI/AI/NoAuth/project.json
+++ b/src/Rules/WebAPI/AI/NoAuth/project.json
@@ -6,10 +6,10 @@
   },
 
   "dependencies": {
-    "Microsoft.ApplicationInsights.AspNet": "__ApplicationInsightsPackageVersion__",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.ApplicationInsights.AspNet": "__ApplicationInsightsPackageVersion__",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.Extensions.Configuration.FileProviderExtensions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/WebAPI/AI/OrganizationalAuth/Single/Startup.cs
+++ b/src/Rules/WebAPI/AI/OrganizationalAuth/Single/Startup.cs
@@ -48,12 +48,15 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
+
             app.UseApplicationInsightsRequestTelemetry();
 
             app.UseApplicationInsightsExceptionTelemetry();

--- a/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
@@ -8,10 +8,10 @@
 
   "dependencies": {
     "Microsoft.ApplicationInsights.AspNet": "__ApplicationInsightsPackageVersion__",
-    "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.Extensions.Configuration.FileProviderExtensions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/WebAPI/OrganizationalAuth/Single/Startup.cs
+++ b/src/Rules/WebAPI/OrganizationalAuth/Single/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -44,12 +45,15 @@ namespace $safeprojectname$
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-$if$ ($aspnet_useplatformhandler$ == false)
+            loggerFactory.AddDebug();$if$ ($aspnet_useplatformhandler$ == false)
 $else$
-
             app.UseIISPlatformHandler();
 $endif$
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+            });
+
             app.UseJwtBearerAuthentication(new JwtBearerOptions
             {
                 AutomaticAuthenticate = true,

--- a/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
@@ -7,10 +7,9 @@
   },
 
   "dependencies": {
-    "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0-rc1-final",$if$ ($aspnet_useplatformhandler$ == false)
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$else$
+    "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$endif$
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.Extensions.Configuration.FileProviderExtensions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",


### PR DESCRIPTION
Also removes conditional inclusion of the IISPlatformHandler package, since this is now needed for all templates due to the code in program.cs

@Tratcher , @rustd , @davidfowl 
