### PR TITLE
Add Development environment info to error page

### DIFF
--- a/src/BaseTemplates/StarterWeb/Views/Shared/Error.cshtml
+++ b/src/BaseTemplates/StarterWeb/Views/Shared/Error.cshtml
@@ -4,3 +4,11 @@
 
 <h1 class="text-danger">Error.</h1>
 <h2 class="text-danger">An error occurred while processing your request.</h2>
+
+<h3>Development Mode</h3>
+<p>
+    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
+</p>
+<p>
+    <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
+</p>


### PR DESCRIPTION
If you are not running from VS, then by default you are not in
development environment (until you set an environment variable). Adding
some info to the non-Development error page to help out folks developing
outside of VS.

Resolves #351 

cc @coolcsh for his input on whether the text would have helped him, since he ran into this prepping for a demo
