### PR TITLE
Update templates for changes in EF service registration

### DIFF
--- a/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
@@ -49,10 +49,8 @@ namespace $safeprojectname$
             // Add framework services.
             services.AddApplicationInsightsTelemetry(Configuration);
 
-            services.AddEntityFramework()
-                .AddSqlServer()
-                .AddDbContext<ApplicationDbContext>(options =>
-                    options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]));
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]));
 
             services.AddIdentity<ApplicationUser, IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>()

--- a/src/Rules/StarterWeb/IndividualAuth/Data/ApplicationDbContext.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Data/ApplicationDbContext.cs
@@ -10,6 +10,11 @@ namespace $safeprojectname$.Data
 {
     public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);

--- a/src/Rules/StarterWeb/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Startup.cs
@@ -43,10 +43,8 @@ namespace $safeprojectname$
         public void ConfigureServices(IServiceCollection services)
         {
             // Add framework services.
-            services.AddEntityFramework()
-                .AddSqlServer()
-                .AddDbContext<ApplicationDbContext>(options =>
-                    options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]));
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]));
 
             services.AddIdentity<ApplicationUser, IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>()


### PR DESCRIPTION
- No longer need to call AddEntityFramework and AddSqlServer. Only AddDbContext is needed.
- Need a constructor on the context that takes DbContextOptions
  - Previous "magic" that allowed the parameterless constructor has been removed
  - Identity repro will be updated with the new constructor patterns soon

@rowanmiller @divega
