### PR TITLE
Remove web command profile from WebAPI launchSetting.json

### DIFF
--- a/src/Rules/WebAPI/WindowsAuth/Properties/launchSettings.json
+++ b/src/Rules/WebAPI/WindowsAuth/Properties/launchSettings.json
@@ -11,14 +11,6 @@
       "environmentVariables" : {
         "ASPNET_ENVIRONMENT": "Development"
       }
-    },
-    "web": {
-      "commandName" : "web",
-      "launchBrowser": true,
-      "launchUrl": "api/values",
-      "environmentVariables" : {
-        "ASPNET_ENVIRONMENT": "Development"
-      }
     }
   }
 }


### PR DESCRIPTION
Fixes #432 

@rustd 
@BillHiebert 

Since we no longer have a web profile by default, we should remove this from the template.
