### PR TITLE
Use new to create DbContext for running Migrate

### DIFF
--- a/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
@@ -91,11 +91,10 @@ $endif$
                 // For more details on creating database during deployment see http://go.microsoft.com/fwlink/?LinkID=615859
                 try
                 {
-                    using (var serviceScope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>()
-                        .CreateScope())
+                    using (var context = new ApplicationDbContext(
+                        app.ApplicationServices.GetRequiredService<DbContextOptions<ApplicationDbContext>>()))
                     {
-                        serviceScope.ServiceProvider.GetService<ApplicationDbContext>()
-                             .Database.Migrate();
+                        context.Database.Migrate();
                     }
                 }
                 catch { }

--- a/src/Rules/StarterWeb/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Startup.cs
@@ -83,11 +83,10 @@ $endif$
                 // For more details on creating database during deployment see http://go.microsoft.com/fwlink/?LinkID=615859
                 try
                 {
-                    using (var serviceScope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>()
-                        .CreateScope())
+                    using (var context = new ApplicationDbContext(
+                        app.ApplicationServices.GetRequiredService<DbContextOptions<ApplicationDbContext>>()))
                     {
-                        serviceScope.ServiceProvider.GetService<ApplicationDbContext>()
-                             .Database.Migrate();
+                        context.Database.Migrate();
                     }
                 }
                 catch { }


### PR DESCRIPTION
This is an optional change. The code already there should still work, but this ia a new option that is available because of the EF D.I. changes.
