### PR TITLE
Rename "ASP.NET Core 1" references to "ASP.NET Core"

### DIFF
--- a/src/BaseTemplates/DNXEmptyWeb.vstemplate
+++ b/src/BaseTemplates/DNXEmptyWeb.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>ASP.NET Core 1 Empty Web Application</Name>
-    <Description>A project for creating an empty ASP.NET Core 1 web application</Description>
+    <Name>ASP.NET Core Empty Web Application</Name>
+    <Description>A project for creating an empty ASP.NET Core web application</Description>
     <Icon>Empty.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/DNXStarterWeb.vstemplate
+++ b/src/BaseTemplates/DNXStarterWeb.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>ASP.NET Core 1 Web Application</Name>
-    <Description>A project for creating an ASP.NET Core 1 Starter Web Application</Description>
+    <Name>ASP.NET Core Web Application</Name>
+    <Description>A project for creating an ASP.NET Core Starter Web Application</Description>
     <Icon>WebApplication.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/DNXWebAPI.vstemplate
+++ b/src/BaseTemplates/DNXWebAPI.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>ASP.NET Core 1 Web API</Name>
-    <Description>A project for creating an ASP.NET Core 1 Web API</Description>
+    <Name>ASP.NET Core Web API</Name>
+    <Description>A project for creating an ASP.NET Core Web API</Description>
     <Icon>WebAPI.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/EmptyWeb.vstemplate
+++ b/src/BaseTemplates/EmptyWeb.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>ASP.NET Core 1 Preview Empty Web Application</Name>
-    <Description>A project for creating an empty ASP.NET Core 1 Preview web application</Description>
+    <Name>ASP.NET Core Empty Web Application</Name>
+    <Description>A project for creating an empty ASP.NET Core web application</Description>
     <Icon>Empty.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/EmptyWeb/Project_Readme.html
+++ b/src/BaseTemplates/EmptyWeb/Project_Readme.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title>Welcome to ASP.NET Core 1</title>
+    <title>Welcome to ASP.NET Core</title>
     <style>
         html {
             background: #f1f1f1;
@@ -128,12 +128,12 @@
 <body>
 
     <div id="header">
-        <h1>Welcome to ASP.NET Core 1</h1>
+        <h1>Welcome to ASP.NET Core</h1>
         <span>
             We've made some big updates in this release, so it’s <b>important</b> that you spend
             a few minutes to learn what’s new.
         </span>
-        <p>You've created a new ASP.NET Core 1 project. <a href="http://go.microsoft.com/fwlink/?LinkId=518016">Learn what's new</a></p>
+        <p>You've created a new ASP.NET Core project. <a href="http://go.microsoft.com/fwlink/?LinkId=518016">Learn what's new</a></p>
     </div>
 
     <div id="main">
@@ -160,8 +160,8 @@
         <div class="section">
             <h2>Overview</h2>
             <ul>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core 1</a></li>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core 1 such as Startup and middleware.</a></li>
+                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core</a></li>
+                <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core such as Startup and middleware.</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkId=398602">Working with Data</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkId=398603">Security</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=699321">Client side development</a></li>

--- a/src/BaseTemplates/StarterWeb.vstemplate
+++ b/src/BaseTemplates/StarterWeb.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>ASP.NET Core 1 Preview Web Application</Name>
-    <Description>A project for creating an ASP.NET Core 1 Preview Starter Web Application</Description>
+    <Name>ASP.NET Core Web Application</Name>
+    <Description>A project for creating an ASP.NET Core Starter Web Application</Description>
     <Icon>WebApplication.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/StarterWeb/Project_Readme.html
+++ b/src/BaseTemplates/StarterWeb/Project_Readme.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title>Welcome to ASP.NET Core 1</title>
+    <title>Welcome to ASP.NET Core</title>
     <style>
         html {
             background: #f1f1f1;
@@ -128,12 +128,12 @@
 <body>
 
     <div id="header">
-        <h1>Welcome to ASP.NET Core 1</h1>
+        <h1>Welcome to ASP.NET Core</h1>
         <span>
             We've made some big updates in this release, so it’s <b>important</b> that you spend
             a few minutes to learn what’s new.
         </span>
-        <p>You've created a new ASP.NET Core 1 project. <a href="http://go.microsoft.com/fwlink/?LinkId=518016">Learn what's new</a></p>
+        <p>You've created a new ASP.NET Core project. <a href="http://go.microsoft.com/fwlink/?LinkId=518016">Learn what's new</a></p>
     </div>
 
     <div id="main">
@@ -160,8 +160,8 @@
         <div class="section">
             <h2>Overview</h2>
             <ul>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core 1</a></li>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core 1 such as Startup and middleware.</a></li>
+                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core</a></li>
+                <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core such as Startup and middleware.</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkId=398602">Working with Data</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkId=398603">Security</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=699321">Client side development</a></li>

--- a/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
+++ b/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
@@ -89,8 +89,8 @@
     <div class="col-md-3">
         <h2>Overview</h2>
         <ul>
-            <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core 1</a></li>
-            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core 1 such as Startup and middleware.</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core such as Startup and middleware.</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=398602">Working with Data</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=398603">Security</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkID=699321">Client side development</a></li>

--- a/src/BaseTemplates/WebAPI.vstemplate
+++ b/src/BaseTemplates/WebAPI.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>ASP.NET Core 1 Preview Web API</Name>
-    <Description>A project for creating an ASP.NET Core 1 Preview Web API</Description>
+    <Name>ASP.NET Core Web API</Name>
+    <Description>A project for creating an ASP.NET Core Web API</Description>
     <Icon>WebAPI.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>Web</ProjectSubType>

--- a/src/BaseTemplates/WebAPI/Project_Readme.html
+++ b/src/BaseTemplates/WebAPI/Project_Readme.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title>Welcome to ASP.NET Core 1</title>
+    <title>Welcome to ASP.NET Core</title>
     <style>
         html {
             background: #f1f1f1;
@@ -128,12 +128,12 @@
 <body>
 
     <div id="header">
-        <h1>Welcome to ASP.NET Core 1</h1>
+        <h1>Welcome to ASP.NET Core</h1>
         <span>
             We've made some big updates in this release, so it’s <b>important</b> that you spend
             a few minutes to learn what’s new.
         </span>
-        <p>You've created a new ASP.NET Core 1 project. <a href="http://go.microsoft.com/fwlink/?LinkId=518016">Learn what's new</a></p>
+        <p>You've created a new ASP.NET Core project. <a href="http://go.microsoft.com/fwlink/?LinkId=518016">Learn what's new</a></p>
     </div>
 
     <div id="main">
@@ -160,8 +160,8 @@
         <div class="section">
             <h2>Overview</h2>
             <ul>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core 1</a></li>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core 1 such as Startup and middleware.</a></li>
+                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core</a></li>
+                <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core such as Startup and middleware.</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkId=398602">Working with Data</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkId=398603">Security</a></li>
                 <li><a href="http://go.microsoft.com/fwlink/?LinkID=699321">Client side development</a></li>

--- a/src/Templates.xml
+++ b/src/Templates.xml
@@ -4,8 +4,8 @@
     <Template Name="Empty" BaseTemplateID="Microsoft.DNX.CSharp.EmptyWeb" Order="8010">
       <Icon>Resources\Empty.png</Icon>
       <PreviewImage>Resources\Empty.png</PreviewImage>
-      <Summary>An empty project template for creating an ASP.NET Core 1 application. This template does not have any content in it.</Summary>
-      <Description>An empty project template for creating an ASP.NET Core 1 application. This template does not have any content in it.</Description>
+      <Summary>An empty project template for creating an ASP.NET Core application. This template does not have any content in it.</Summary>
+      <Description>An empty project template for creating an ASP.NET Core application. This template does not have any content in it.</Description>
       <UIFilters>DNXProject</UIFilters>
       <Options>
         <Authentication Default="NoAuth">
@@ -38,8 +38,8 @@
     <Template Name="Web Application" BaseTemplateID="Microsoft.DNX.CSharp.StarterWeb" Order="8030">
       <Icon>Resources\WebApplication.png</Icon>
       <PreviewImage>Resources\WebApplication.png</PreviewImage>
-      <Summary>A project template for creating an ASP.NET Core 1 application. The template uses ASP.NET MVC and can be used to build Web Applications and RESTful HTTP Services.</Summary>
-      <Description>A project template for creating an ASP.NET Core 1 application. The template uses ASP.NET MVC and can be used to build Web Applications and RESTful HTTP Services.</Description>
+      <Summary>A project template for creating an ASP.NET Core application. The template uses ASP.NET MVC and can be used to build Web Applications and RESTful HTTP Services.</Summary>
+      <Description>A project template for creating an ASP.NET Core application. The template uses ASP.NET MVC and can be used to build Web Applications and RESTful HTTP Services.</Description>
       <UIFilters>DNXProject</UIFilters>
       <Options>
         <Authentication Default="IndividualAuth">


### PR DESCRIPTION
Fix the branding. Also changing this in tooling as well, sent out separate review for that.

@joeloff @rustd 
