### PR TITLE
:bug: Remove extra dots from page title. Fixes #465

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Views/Account/ForgotPassword.cshtml
+++ b/src/Rules/StarterWeb/IndividualAuth/Views/Account/ForgotPassword.cshtml
@@ -3,7 +3,7 @@
     ViewData["Title"] = "Forgot your password?";
 }
 
-<h2>@ViewData["Title"].</h2>
+<h2>@ViewData["Title"]</h2>
 <p>
     For more information on how to enable reset password please see this <a href="http://go.microsoft.com/fwlink/?LinkID=532713">article</a>.
 </p>


### PR DESCRIPTION
An itsy-bitsy one
The defualt title ends with a question mark, so by
default user is presented with the extra dot:

```
Forgot your password?.
```

Thanks!
