### PR TITLE
:art: Use string interpolation when building email links

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
@@ -114,7 +114,7 @@ namespace $safeprojectname$.Controllers
                     //var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                     //var callbackUrl = Url.Action("ConfirmEmail", "Account", new { userId = user.Id, code = code }, protocol: HttpContext.Request.Scheme);
                     //await _emailSender.SendEmailAsync(model.Email, "Confirm your account",
-                    //    "Please confirm your account by clicking this link: <a href=\"" + callbackUrl + "\">link</a>");
+                    //    $"Please confirm your account by clicking this link: <a href='{callbackUrl}'>link</a>");
                     await _signInManager.SignInAsync(user, isPersistent: false);
                     _logger.LogInformation(3, "User created a new account with password.");
                     return RedirectToLocal(returnUrl);
@@ -274,7 +274,7 @@ namespace $safeprojectname$.Controllers
                 //var code = await _userManager.GeneratePasswordResetTokenAsync(user);
                 //var callbackUrl = Url.Action("ResetPassword", "Account", new { userId = user.Id, code = code }, protocol: HttpContext.Request.Scheme);
                 //await _emailSender.SendEmailAsync(model.Email, "Reset Password",
-                //   "Please reset your password by clicking here: <a href=\"" + callbackUrl + "\">link</a>");
+                //   $"Please reset your password by clicking here: <a href='{callbackUrl}'>link</a>");
                 //return View("ForgotPasswordConfirmation");
             }
 


### PR DESCRIPTION
This commit simplifies email links generation by using
C# 6 string interpolation feature.
The quotes in HTML5 are double, single or no quotes.
This commit uses single quotes to not use escape chars.

Thanks!
