### PR TITLE
Move web.config

### DIFF
--- a/src/BaseTemplates/EmptyWeb.vstemplate
+++ b/src/BaseTemplates/EmptyWeb.vstemplate
@@ -22,9 +22,8 @@
       <ProjectItem ReplaceParameters="true">project.json</ProjectItem>
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">Startup.cs</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="Project_Readme.html" OpenInWebBrowser="true">Project_Readme.html</ProjectItem>
-      <Folder Name="wwwroot" TargetFolderName="wwwroot">
-        <ProjectItem ReplaceParameters="true" TargetFileName="web.config">web.config</ProjectItem>
-      </Folder>
+      <ProjectItem ReplaceParameters="true" TargetFileName="web.config">web.config</ProjectItem>
+      <Folder Name="wwwroot" TargetFolderName="wwwroot"/>
     </Project>
   </TemplateContent>
 </VSTemplate>

--- a/src/BaseTemplates/EmptyWeb/project.json
+++ b/src/BaseTemplates/EmptyWeb/project.json
@@ -33,7 +33,8 @@ $endif$
   },
 
   "content": [
-    "wwwroot"
+    "wwwroot",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/BaseTemplates/EmptyWeb/web.config
+++ b/src/BaseTemplates/EmptyWeb/web.config
@@ -9,6 +9,6 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" startupTimeLimit="3600" stdoutLogEnabled="false"/>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
   </system.webServer>
 </configuration>

--- a/src/BaseTemplates/StarterWeb.vstemplate
+++ b/src/BaseTemplates/StarterWeb.vstemplate
@@ -27,6 +27,7 @@
       <ProjectItem ReplaceParameters="true" TargetFileName="project.json">project.json</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="Project_Readme.html" OpenInWebBrowser="true">Project_Readme.html</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="Startup.cs">Startup.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="web.config">web.config</ProjectItem>
       <Folder Name="Controllers" TargetFolderName="Controllers">
         <ProjectItem ReplaceParameters="true" TargetFileName="HomeController.cs">HomeController.cs</ProjectItem>
       </Folder>
@@ -2422,7 +2423,6 @@
       </Folder>
       <Folder Name="wwwroot" TargetFolderName="wwwroot">
         <ProjectItem ReplaceParameters="false" TargetFileName="favicon.ico">favicon.ico</ProjectItem>
-        <ProjectItem ReplaceParameters="false" TargetFileName="web.config">web.config</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="_references.js">_references.js</ProjectItem>
         <Folder Name="css" TargetFolderName="css">
           <ProjectItem ReplaceParameters="false" TargetFileName="site.css">site.css</ProjectItem>

--- a/src/BaseTemplates/StarterWeb/project.json
+++ b/src/BaseTemplates/StarterWeb/project.json
@@ -46,7 +46,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/BaseTemplates/StarterWeb/web.config
+++ b/src/BaseTemplates/StarterWeb/web.config
@@ -9,6 +9,6 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" startupTimeLimit="3600" stdoutLogEnabled="false"/>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
   </system.webServer>
 </configuration>

--- a/src/BaseTemplates/WebAPI.vstemplate
+++ b/src/BaseTemplates/WebAPI.vstemplate
@@ -23,15 +23,14 @@
       <ProjectItem ReplaceParameters="true" TargetFileName="project.json">project.json</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="Project_Readme.html" OpenInWebBrowser="true">Project_Readme.html</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="Startup.cs">Startup.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="web.config">web.config</ProjectItem>
       <Folder Name="Controllers" TargetFolderName="Controllers">
         <ProjectItem ReplaceParameters="true" TargetFileName="ValuesController.cs">ValuesController.cs</ProjectItem>
       </Folder>
       <Folder Name="Properties" TargetFolderName="Properties">
         <ProjectItem ReplaceParameters="true" TargetFileName="launchSettings.json">launchSettings.json</ProjectItem>
       </Folder>
-      <Folder Name="wwwroot" TargetFolderName="wwwroot">
-        <ProjectItem ReplaceParameters="true" TargetFileName="web.config">web.config</ProjectItem>
-      </Folder>
+      <Folder Name="wwwroot" TargetFolderName="wwwroot"/>
     </Project>
   </TemplateContent>
 </VSTemplate>

--- a/src/BaseTemplates/WebAPI/project.json
+++ b/src/BaseTemplates/WebAPI/project.json
@@ -41,7 +41,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/BaseTemplates/WebAPI/web.config
+++ b/src/BaseTemplates/WebAPI/web.config
@@ -9,6 +9,6 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" startupTimeLimit="3600" stdoutLogEnabled="false"/>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
   </system.webServer>
 </configuration>

--- a/src/Rules/StarterWeb/AI/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/project.json
@@ -57,7 +57,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/Rules/StarterWeb/AI/NoAuth/project.json
+++ b/src/Rules/StarterWeb/AI/NoAuth/project.json
@@ -48,7 +48,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/project.json
@@ -51,7 +51,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/project.json
@@ -51,7 +51,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/Rules/StarterWeb/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/IndividualAuth/project.json
@@ -56,7 +56,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
@@ -50,7 +50,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/Rules/WebAPI/AI/NoAuth/project.json
+++ b/src/Rules/WebAPI/AI/NoAuth/project.json
@@ -42,7 +42,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
@@ -41,7 +41,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [

--- a/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
@@ -40,7 +40,8 @@ $endif$
   "content": [
     "wwwroot",
     "Views",
-    "appsettings.json"
+    "appsettings.json",
+    "web.config"
   ],
 
   "exclude": [


### PR DESCRIPTION
We now expect to have the `web.config` file to be located in the application root instead of `wwwroot`. We also made some changes to the default visible attributes.

cc @Tratcher @shirhatti @phenning 
