### PR TITLE
Add missing tools node to WebAPI project.json

### DIFF
--- a/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
@@ -39,6 +39,10 @@ $if$ ($context$ == WebCore) $else$
     "win7-x86": { }
   },
 $endif$
+  "tools": {
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-*"
+  },
+
   "content": [
     "wwwroot",
     "Views",

--- a/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
@@ -38,6 +38,10 @@ $if$ ($context$ == WebCore) $else$
     "win7-x86": { }
   },
 $endif$
+  "tools": {
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-*"
+  },
+
   "content": [
     "wwwroot",
     "Views",


### PR DESCRIPTION
@phenning I think these `project.json` are missing the `"Microsoft.AspNetCore.Server.IISIntegration.Tools"` dependencies even though they are using `dotnet publish-iis`. If you agree, we should seek rc2 approval for these updates.
