### PR TITLE
:bug: Remove orphaned <text> tag. Fixes #553

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Views/Manage/Index.cshtml
+++ b/src/Rules/StarterWeb/IndividualAuth/Views/Manage/Index.cshtml
@@ -44,7 +44,7 @@
                 }
                 else
                 {
-                    <text><a asp-controller="Manage" asp-action="AddPhoneNumber" class="btn-bracketed">Add</a>
+                    <a asp-controller="Manage" asp-action="AddPhoneNumber" class="btn-bracketed">Add</a>
                 }*@
         </dd>
 


### PR DESCRIPTION
This fixes following runtime error:

```
Error @ (1761:46,21)(4) - [The "text" element was not closed.
```

The tag should be removed as part of aspnet/Templates#470
but somehow slipped out of actual commits.

Thanks!
