### PR TITLE
Fix display of carousel images on older browsers

### DIFF
--- a/src/BaseTemplates/StarterWeb/wwwroot/css/site.css
+++ b/src/BaseTemplates/StarterWeb/wwwroot/css/site.css
@@ -22,6 +22,13 @@ textarea {
     font-size: 20px;
     line-height: 1.4;
 }
+
+/* Make .svg files in the carousel display properly in older browsers */
+.carousel-inner .item img[src$=".svg"]
+{
+    width: 100%;
+}
+
 /* Hide/rearrange for smaller screens */
 @media screen and (max-width: 767px) {
   /* Hide captions */

--- a/src/BaseTemplates/StarterWeb/wwwroot/css/site.min.css
+++ b/src/BaseTemplates/StarterWeb/wwwroot/css/site.min.css
@@ -1,1 +1,1 @@
-body{padding-top:50px;padding-bottom:20px}.body-content{padding-left:15px;padding-right:15px}input,select,textarea{max-width:280px}.carousel-caption p{font-size:20px;line-height:1.4}@media screen and (max-width:767px){.carousel-caption{display:none}}
+body{padding-top:50px;padding-bottom:20px}.body-content{padding-left:15px;padding-right:15px}input,select,textarea{max-width:280px}.carousel-caption p{font-size:20px;line-height:1.4}.carousel-inner .item img[src$=".svg"]{width:100%}@media screen and (max-width:767px){.carousel-caption{display:none}}


### PR DESCRIPTION
This applies a width: 100% for only svg files in the carousel

//cc @joeloff @madskristensen @sayedihashimi @mlorbetske 
