### PR TITLE
Update template's usage of Entity Framework tools

### DIFF
--- a/src/Rules/StarterWeb/AI/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/project.json
@@ -19,9 +19,13 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.Tools": {
+    "Microsoft.EntityFrameworkCore.Design": {
       "version": "__ToolsPackageVersion__",
+      "type": "build"
+    },
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
+    "Microsoft.EntityFrameworkCore.SqlServer.Design": {
+      "version": "__AspNetCorePackageVersion__",
       "type": "build"
     },
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
@@ -58,13 +62,7 @@
       "version": "__ToolsPackageVersion__",
       "imports": "portable-net45+win8+dnxcore50"
     },$endif$
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "__ToolsPackageVersion__",
-      "imports": [
-        "portable-net45+win8+dnxcore50",
-        "portable-net45+win8"
-      ]
-    },
+    "Microsoft.EntityFrameworkCore.Tools": "__ToolsPackageVersion__",
     "Microsoft.Extensions.SecretManager.Tools": {
       "version": "__ToolsPackageVersion__",
       "imports": "portable-net45+win8+dnxcore50"

--- a/src/Rules/StarterWeb/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/IndividualAuth/project.json
@@ -18,9 +18,13 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.Tools": {
+    "Microsoft.EntityFrameworkCore.Design": {
       "version": "__ToolsPackageVersion__",
+      "type": "build"
+    },
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
+    "Microsoft.EntityFrameworkCore.SqlServer.Design": {
+      "version": "__AspNetCorePackageVersion__",
       "type": "build"
     },
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
@@ -57,13 +61,7 @@
       "version": "__ToolsPackageVersion__",
       "imports": "portable-net45+win8+dnxcore50"
     },$endif$
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "__ToolsPackageVersion__",
-      "imports": [
-        "portable-net45+win8+dnxcore50",
-        "portable-net45+win8"
-      ]
-    },
+    "Microsoft.EntityFrameworkCore.Tools": "__ToolsPackageVersion__",
     "Microsoft.Extensions.SecretManager.Tools": {
       "version": "__ToolsPackageVersion__",
       "imports": "portable-net45+win8+dnxcore50"

--- a/src/project.json
+++ b/src/project.json
@@ -15,9 +15,13 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.Tools": {
+    "Microsoft.EntityFrameworkCore.Design": {
       "version": "__ToolsPackageVersion__",
+      "type": "build"
+    },
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
+    "Microsoft.EntityFrameworkCore.SqlServer.Design": {
+      "version": "__AspNetCorePackageVersion__",
       "type": "build"
     },
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
@@ -72,13 +76,7 @@
       "version": "__ToolsPackageVersion__",
       "imports": "portable-net45+win8+dnxcore50"
     },
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "__ToolsPackageVersion__",
-      "imports": [
-        "portable-net45+win8+dnxcore50",
-        "portable-net45+win8"
-      ]
-    },
+    "Microsoft.EntityFrameworkCore.Tools": "__ToolsPackageVersion__",
     "Microsoft.Extensions.SecretManager.Tools": {
       "version": "__ToolsPackageVersion__",
       "imports": "portable-net45+win8+dnxcore50"


### PR DESCRIPTION
Cref https://github.com/aspnet/EntityFramework/pull/5635. This is in for preview 2.

For preview 2 and beyond, we will be instructing users to put "Microsoft.EntityFrameworkCore.Tools" in the "tools" section of project.json, and "Microsoft.EntityFrameworkCore.Design" into "dependencies".

cc @phenning 
