### PR TITLE
Remove npm artifact references from DnxInvisibleContent ItemGroup

### DIFF
--- a/src/BaseTemplates/StarterWeb/StarterWeb.xproj
+++ b/src/BaseTemplates/StarterWeb/StarterWeb.xproj
@@ -18,8 +18,6 @@
   <ItemGroup>
     <DnxInvisibleContent Include="bower.json" />
     <DnxInvisibleContent Include=".bowerrc" />
-    <DnxInvisibleContent Include="package.json" />
-    <DnxInvisibleContent Include=".npmrc" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
With the removal of `package.json` from the "StarterWeb" template, it makes less sense to reference the `package.json` and `.npmrc` npm artifacts in the "DnxInvisibleContent" ItemGroup within the XPROJ file. This PR removes those 2 items.
