### PR TITLE
Remove npm artifact references from DnxInvisibleContent ItemGroup

### DIFF
--- a/src/BaseTemplates/EmptyWeb/EmptyWeb.xproj
+++ b/src/BaseTemplates/EmptyWeb/EmptyWeb.xproj
@@ -20,8 +20,6 @@
   <ItemGroup>
     <DnxInvisibleContent Include="bower.json" />
     <DnxInvisibleContent Include=".bowerrc" />
-    <DnxInvisibleContent Include="package.json" />
-    <DnxInvisibleContent Include=".npmrc" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
This PR is the same as https://github.com/aspnet/Templates/pull/594, except that it applies to the "EmptyWeb" template. I suspect that we want the "EmptyWeb" template to be consistent.
