### PR TITLE
Remove npm global Gulp installation task

### DIFF
--- a/test/VerifyTemplates.csproj
+++ b/test/VerifyTemplates.csproj
@@ -237,7 +237,6 @@
   </Target>
   
   <Target Name="InstallNpmPackages">
-    <Exec Command="npm install -g gulp" Condition="!Exists('$(AppData)\npm\gulp') or '$(ForceNpmInstall)' == 'true'" />
     <Exec Command="npm install -g bower" Condition="!Exists('$(AppData)\npm\bower') or '$(ForceNpmInstall)' == 'true'" />
   </Target>
   


### PR DESCRIPTION
Since Gulp has been removed from the "StarterWeb" template, there's no longer a need to have MSBuild install the Gulp module. This PR removes the associated `Exec` task from the `InstallNpmPackages` target.
