### PR TITLE
Remove exclusions of node_modules folder from compilation

### DIFF
--- a/src/BaseTemplates/EmptyWeb/project.json
+++ b/src/BaseTemplates/EmptyWeb/project.json
@@ -28,12 +28,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/BaseTemplates/StarterWeb/project.json
+++ b/src/BaseTemplates/StarterWeb/project.json
@@ -53,12 +53,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/BaseTemplates/WebAPI/project.json
+++ b/src/BaseTemplates/WebAPI/project.json
@@ -36,12 +36,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/Rules/StarterWeb/AI/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/project.json
@@ -89,12 +89,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/Rules/StarterWeb/AI/NoAuth/project.json
+++ b/src/Rules/StarterWeb/AI/NoAuth/project.json
@@ -54,12 +54,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/Common/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/Common/project.json
@@ -63,12 +63,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/Common/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/Common/project.json
@@ -63,12 +63,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/Rules/StarterWeb/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/IndividualAuth/project.json
@@ -88,12 +88,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
@@ -62,12 +62,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/Rules/WebAPI/AI/NoAuth/project.json
+++ b/src/Rules/WebAPI/AI/NoAuth/project.json
@@ -37,12 +37,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
@@ -45,12 +45,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {

--- a/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
@@ -44,12 +44,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-    "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 $if$ ($context$ == WebCore)
   "runtimeOptions": {


### PR DESCRIPTION
The `project.json` files for the various project templates are currently excluding npm's `node_modules` folder during compilation. This seems unnecessary. There will no longer be a `node_modules` folder by default, since npm packages are no longer included in the templates. For example, Gulp and all of its plugins were removed.
