### PR TITLE
Remove unnecessary npm & Bower references from .csproj files

### DIFF
--- a/src/BaseTemplates/BaseProjectTemplates.csproj
+++ b/src/BaseTemplates/BaseProjectTemplates.csproj
@@ -112,8 +112,6 @@
       <FilesToVerify Remove="**\*.ico"/>
       <FilesToVerify Remove="**\*.min.js"/>
       <FilesToVerify Remove="**\*.min.css"/>
-      <FilesToVerify Remove="StarterWeb\node_modules\**\*.*"/>
-      <FilesToVerify Remove="StarterWeb\bower_components\**\*.*"/>
       <FilesToVerify Remove="StarterWeb\wwwroot\lib\bootstrap\**\*.*"/>
       <FilesToVerify Remove="StarterWeb\wwwroot\lib\jquery*\**\*.*"/>
       <FilesToVerify Remove="StarterWeb\wwwroot\lib\**\*.*"/>
@@ -123,7 +121,6 @@
     <ItemGroup>
       <FilesToVerify Remove="StarterWeb\.bowerrc"/>
       <FilesToVerify Remove="StarterWeb\bower.json"/>
-      <FilesToVerify Remove="StarterWeb\package.json"/>
     </ItemGroup>
     <VerifyBOM FileList="@(FilesToVerify)"/>
     <ItemGroup>

--- a/test/VerifyTemplates.csproj
+++ b/test/VerifyTemplates.csproj
@@ -211,7 +211,6 @@
       <ExtractedFiles Remove="@(ExtractedFiles)"/>
       <ExtractedFiles Include="$(TestPath)\**\*.*" Condition="'$(IsRulesPackage)' == 'false'"/>
       <ExtractedFiles Remove="$(TestPath)\wwwroot\**\*.*" Condition="'$(IsRulesPackage)' == 'false'"/>
-      <ExtractedFiles Remove="$(TestPath)\node_modules\**\*.*" Condition="'$(IsRulesPackage)' == 'false'"/>
     </ItemGroup>
     <RegexReplace Files="@(ExtractedFiles)" Find="\$safeprojectname\$" Condition="('%(Extension)' == '.cshtml' or '%(Extension)' == '.cs' or '%(Extension)' == '.vstemplate' or '%(Extension)' == '.xproj')" Replace="$(TargetName)" />
     <RegexReplace Files="@(ExtractedFiles)" Find="\$guid1\$" Condition="('%(Extension)' == '.cshtml' or '%(Extension)' == '.cs' or '%(Extension)' == '.vstemplate' or '%(Extension)' == '.xproj')" Replace="$(ProjectGuid)" />
@@ -273,7 +272,6 @@
       <ExtractedFiles Remove="@(ExtractedFiles)"/>
       <ExtractedFiles Include="$(TestPath)\**\*.*"/>
       <ExtractedFiles Remove="$(TestPath)\wwwroot\**\*.*"/>
-      <ExtractedFiles Remove="$(TestPath)\node_modules\**\*.*"/>
     </ItemGroup>
 
     <RegexReplace Files="@(ExtractedFiles)" Find="\$safeprojectname\$" Condition="('%(Extension)' == '.cshtml' or '%(Extension)' == '.cs' or '%(Extension)' == '.vstemplate' or '%(Extension)' == '.xproj')" Replace="$(TargetName)" />


### PR DESCRIPTION
This PR removes a reference to Bower's default `bower_components` folder. This folder will never be created, since the `.bowerrc` file tells Bower to put the assets in `wwwroot\lib`. Also included in this PR is the removal of the `node_modules` and `package.json` artifacts, neither of which exist due to the removal of npm dependencies from the project templates.
