### PR TITLE
Remove links indicating Gulp usage in templates

### DIFF
--- a/src/BaseTemplates/EmptyWeb/Project_Readme.html
+++ b/src/BaseTemplates/EmptyWeb/Project_Readme.html
@@ -141,7 +141,7 @@
             <h2>This application consists of:</h2>
             <ul>
                 <li>Sample pages using ASP.NET Core MVC</li>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518007">Gulp</a> and <a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
+                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
                 <li>Theming using <a href="http://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
             </ul>
         </div>

--- a/src/BaseTemplates/StarterWeb/Project_Readme.html
+++ b/src/BaseTemplates/StarterWeb/Project_Readme.html
@@ -141,7 +141,7 @@
             <h2>This application consists of:</h2>
             <ul>
                 <li>Sample pages using ASP.NET Core MVC</li>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518007">Gulp</a> and <a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
+                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
                 <li>Theming using <a href="http://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
             </ul>
         </div>

--- a/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
+++ b/src/BaseTemplates/StarterWeb/Views/Home/Index.cshtml
@@ -70,7 +70,7 @@
         <h2>Application uses</h2>
         <ul>
             <li>Sample pages using ASP.NET Core MVC</li>
-            <li><a href="http://go.microsoft.com/fwlink/?LinkId=518007">Gulp</a> and <a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
             <li>Theming using <a href="http://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
         </ul>
     </div>

--- a/src/BaseTemplates/WebAPI/Project_Readme.html
+++ b/src/BaseTemplates/WebAPI/Project_Readme.html
@@ -141,7 +141,7 @@
             <h2>This application consists of:</h2>
             <ul>
                 <li>Sample pages using ASP.NET Core MVC</li>
-                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518007">Gulp</a> and <a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
+                <li><a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
                 <li>Theming using <a href="http://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
             </ul>
         </div>


### PR DESCRIPTION
This PR removes obsolete hyperlinks which indicate the project templates are using Gulp. 
