### PR TITLE
Replace magic action name strings with nameof operator

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
@@ -112,7 +112,7 @@ namespace $safeprojectname$.Controllers
                     // For more information on how to enable account confirmation and password reset please visit http://go.microsoft.com/fwlink/?LinkID=532713
                     // Send an email with this link
                     //var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-                    //var callbackUrl = Url.Action("ConfirmEmail", "Account", new { userId = user.Id, code = code }, protocol: HttpContext.Request.Scheme);
+                    //var callbackUrl = Url.Action(nameof(ConfirmEmail), "Account", new { userId = user.Id, code = code }, protocol: HttpContext.Request.Scheme);
                     //await _emailSender.SendEmailAsync(model.Email, "Confirm your account",
                     //    $"Please confirm your account by clicking this link: <a href='{callbackUrl}'>link</a>");
                     await _signInManager.SignInAsync(user, isPersistent: false);
@@ -145,7 +145,7 @@ namespace $safeprojectname$.Controllers
         public IActionResult ExternalLogin(string provider, string returnUrl = null)
         {
             // Request a redirect to the external login provider.
-            var redirectUrl = Url.Action("ExternalLoginCallback", "Account", new { ReturnUrl = returnUrl });
+            var redirectUrl = Url.Action(nameof(ExternalLoginCallback), "Account", new { ReturnUrl = returnUrl });
             var properties = _signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl);
             return Challenge(properties, provider);
         }
@@ -272,7 +272,7 @@ namespace $safeprojectname$.Controllers
                 // For more information on how to enable account confirmation and password reset please visit http://go.microsoft.com/fwlink/?LinkID=532713
                 // Send an email with this link
                 //var code = await _userManager.GeneratePasswordResetTokenAsync(user);
-                //var callbackUrl = Url.Action("ResetPassword", "Account", new { userId = user.Id, code = code }, protocol: HttpContext.Request.Scheme);
+                //var callbackUrl = Url.Action(nameof(ResetPassword), "Account", new { userId = user.Id, code = code }, protocol: HttpContext.Request.Scheme);
                 //await _emailSender.SendEmailAsync(model.Email, "Reset Password",
                 //   $"Please reset your password by clicking here: <a href='{callbackUrl}'>link</a>");
                 //return View("ForgotPasswordConfirmation");

--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/ManageController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/ManageController.cs
@@ -303,7 +303,7 @@ namespace $safeprojectname$.Controllers
         public IActionResult LinkLogin(string provider)
         {
             // Request a redirect to the external login provider to link a login for the current user
-            var redirectUrl = Url.Action("LinkLoginCallback", "Manage");
+            var redirectUrl = Url.Action(nameof(LinkLoginCallback), "Manage");
             var properties = _signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl, _userManager.GetUserId(User));
             return Challenge(properties, provider);
         }

--- a/src/Rules/StarterWeb/OrganizationalAuth/Multiple/Common/Controllers/AccountController.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Multiple/Common/Controllers/AccountController.cs
@@ -19,7 +19,7 @@ namespace $safeprojectname$.Controllers
 
         public IActionResult SignOut()
         {
-            var callbackUrl = Url.Action("SignedOut", "Account", values: null, protocol: Request.Scheme);
+            var callbackUrl = Url.Action(nameof(SignedOut), "Account", values: null, protocol: Request.Scheme);
             return SignOut(new AuthenticationProperties { RedirectUri = callbackUrl },
                 CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme);
         }

--- a/src/Rules/StarterWeb/OrganizationalAuth/Single/Common/Controllers/AccountController.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Single/Common/Controllers/AccountController.cs
@@ -19,7 +19,7 @@ namespace $safeprojectname$.Controllers
 
         public IActionResult SignOut()
         {
-            var callbackUrl = Url.Action("SignedOut", "Account", values: null, protocol: Request.Scheme);
+            var callbackUrl = Url.Action(nameof(SignedOut), "Account", values: null, protocol: Request.Scheme);
             return SignOut(new AuthenticationProperties { RedirectUri = callbackUrl },
                 CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme);
         }


### PR DESCRIPTION
This PR replaces magic strings being passed as the action name parameters in the `Url.Action` calls. This will help ensure that as controller action methods are renamed, the `Url.Action` calls aren't forgotten. It's also consistent with what's already being done in the `RedirectToAction` calls. 
