### PR TITLE
Revert Microsoft.EntityFrameworkCore.Design reference to .Tools

### DIFF
--- a/src/Rules/StarterWeb/AI/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/project.json
@@ -19,7 +19,7 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.Design": {
+    "Microsoft.EntityFrameworkCore.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
     },

--- a/src/Rules/StarterWeb/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/IndividualAuth/project.json
@@ -18,7 +18,7 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.Design": {
+    "Microsoft.EntityFrameworkCore.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
     },

--- a/src/project.json
+++ b/src/project.json
@@ -15,7 +15,7 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.Design": {
+    "Microsoft.EntityFrameworkCore.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
     },


### PR DESCRIPTION
This reverts part of 15feae9769fe861bc807346383608f45eb89b2ff due to NuGet/Home#3023

Note, `Microsoft.EntityFrameworkCore.Tools` depends on `Microsoft.EntityFrameworkCore.Design`, so it is still referenced transitively.

cc @rowanmiller 
