### PR TITLE
Remove DnxInvisibleContent Bower artifact references

### DIFF
--- a/src/BaseTemplates/EmptyWeb/EmptyWeb.xproj
+++ b/src/BaseTemplates/EmptyWeb/EmptyWeb.xproj
@@ -17,9 +17,5 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <DnxInvisibleContent Include="bower.json" />
-    <DnxInvisibleContent Include=".bowerrc" />
-  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
The "EmptyWeb" template's XPROJ file contains references to the following 2 Bower files:
1. `bower.json`
2. `.bowerrc`

Since neither of these files is included in the template, it's probably best to remove them from the `DnxInvisibleContent` item group altogether. I would expect a "bare bones" project which makes no assumptions with regard to a client-side package manager when I choose the empty project template.
