### PR TITLE
IndividualAuth password resets: get user by email

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
@@ -269,7 +269,7 @@ namespace $safeprojectname$.Controllers
         {
             if (ModelState.IsValid)
             {
-                var user = await _userManager.FindByNameAsync(model.Email);
+                var user = await _userManager.FindByEmailAsync(model.Email);
                 if (user == null || !(await _userManager.IsEmailConfirmedAsync(user)))
                 {
                     // Don't reveal that the user does not exist or is not confirmed
@@ -318,7 +318,7 @@ namespace $safeprojectname$.Controllers
             {
                 return View(model);
             }
-            var user = await _userManager.FindByNameAsync(model.Email);
+            var user = await _userManager.FindByEmailAsync(model.Email);
             if (user == null)
             {
                 // Don't reveal that the user does not exist


### PR DESCRIPTION
Since the user is prompted for an email to reset their password, use
that to look up their user account, rather than the `UserName`
field. This makes a difference if you have decoupled those two fields,
allowing the user to specify their username rather than storing the
email to both.
