### PR TITLE
Update MVC, Kestrel and EF versions to 1.0.1. Explictly add Routing 1…

### DIFF
--- a/Templates.Settings.targets
+++ b/Templates.Settings.targets
@@ -27,8 +27,8 @@
         <TemplateVersion Condition="'$(TemplateVersion)' == ''">Local</TemplateVersion>
         <PackageType Condition="'$(TemplateBuildBranch)' == 'release'">$(ReleasePackageType)</PackageType>
         <PackageType Condition="'$(TemplateBuildBranch)' == 'dev'">$(DevPackageType)</PackageType>
-        <SignedPackageSubPath>artifacts\Signed</SignedPackageSubPath>
-        <ExternalPackageSubPath>artifacts\coherence\ext</ExternalPackageSubPath>
+        <SignedPackageSubPath>Signed</SignedPackageSubPath>
+        <ExternalPackageSubPath>coherence\ext</ExternalPackageSubPath>
         <ApplicationInsightsPackageSource Condition="'$(ApplicationInsightsPackageSource)' == ''">https://www.myget.org/F/applicationinsights/api/v3/index.json</ApplicationInsightsPackageSource>
         <AzureAdPackageSource Condition="'$(AzureAdPackageSource)' == '' and '$(TemplateBuildBranch)' == 'release'">https://www.myget.org/F/azureadwebstackrelease/api/v3/index.json</AzureAdPackageSource>
         <AzureAdPackageSource Condition="'$(AzureAdPackageSource)' == '' and '$(TemplateBuildBranch)' == 'dev'">https://www.myget.org/F/azureadwebstacknightly/api/v3/index.json</AzureAdPackageSource>
@@ -68,6 +68,7 @@
             <CoreAppFile Include="$(CoherencePackageSources)\Microsoft.NETCore.App.*.nupkg"/>
             <NetStandardFile Include="$(CoherencePackageSources)\NETStandard.Library.*.nupkg"/>
             <ToolsFile Include="$(CoherencePackageSources)\Microsoft.AspNetCore.Server.IISIntegration.Tools.*.nupkg"/>
+            <ScaffoldingToolsFile Include="$(CoherencePackageSources)\Microsoft.VisualStudio.Web.CodeGeneration.Tools.*.nupkg"/>
             <AspNetCoreFile Include="$(CoherencePackageSources)\Microsoft.AspNetCore.Mvc.Razor.*.nupkg"/>
         </ItemGroup>
 
@@ -83,6 +84,10 @@
             <Output PropertyName="ToolsSemanticVersion" TaskParameter="SemanticVersion"/>
         </GetFileSemanticVersion>
 
+        <GetFileSemanticVersion Condition="'%(ScaffoldingToolsFile .Identity)' != '' " Filename="%(ScaffoldingToolsFile .Filename)">
+            <Output PropertyName="ScaffoldingSemanticVersion" TaskParameter="SemanticVersion"/>
+        </GetFileSemanticVersion>
+
         <GetFileSemanticVersion Condition="'%(AspNetCoreFile.Identity)' != '' " Filename="%(AspNetCoreFile.Filename)">
             <Output PropertyName="AspNetCoreSemanticVersion" TaskParameter="SemanticVersion"/>
         </GetFileSemanticVersion>
@@ -90,24 +95,27 @@
         <PropertyGroup>
             <!-- The below is a fallback version for external non CI builds -->
             <NetCoreSemanticVersion Condition="'$(PackageSourceExternal)' == ''">-*</NetCoreSemanticVersion>
-            <NetCorePlatformVersion Condition="'$(NetCorePlatformVersion)' == ''">1.0.0$(NetCoreSemanticVersion)</NetCorePlatformVersion>
+            <NetCorePlatformVersion Condition="'$(NetCorePlatformVersion)' == ''">1.0.1$(NetCoreSemanticVersion)</NetCorePlatformVersion>
             <NetStandardVersion Condition="'$(NetStandardVersion)' == ''">1.6</NetStandardVersion>
             <NetStandardSemanticVersion Condition="'$(PackageSourceExternal)' == ''">-*</NetStandardSemanticVersion>
             <NetStandardPlatformVersion Condition="'$(NetStandardPlatformVersion)' == ''">$(NetStandardVersion).0$(NetStandardSemanticVersion)</NetStandardPlatformVersion>
             <ToolsSemanticVersion Condition="'$(PackageSource)' == ''">-*</ToolsSemanticVersion>
             <ToolsPackageVersion Condition="'$(ToolsPackageVersion)' == ''">1.0.0$(ToolsSemanticVersion)</ToolsPackageVersion>
+            <ScaffoldingSemanticVersion Condition="'$(PackageSource)' == ''">-*</ScaffoldingSemanticVersion>
+            <ScaffoldingPackageVersion Condition="'$(ScaffoldingPackageVersion)' == ''">1.0.0$(ScaffoldingSemanticVersion)</ScaffoldingPackageVersion>
             <AspNetCoreSemanticVersion Condition="'$(PackageSource)' == ''">-*</AspNetCoreSemanticVersion>
-            <AspNetCorePackageVersion Condition="'$(AspNetCorePackageVersion)' == ''">1.0.0$(AspNetCoreSemanticVersion)</AspNetCorePackageVersion>
+            <AspNetCorePackageVersion Condition="'$(AspNetCorePackageVersion)' == ''">1.0.1$(AspNetCoreSemanticVersion)</AspNetCorePackageVersion>
         </PropertyGroup>
 
         <Message Text="NetCorePlatformVersion: $(NetCorePlatformVersion)"/>
         <Message Text="NetStandardPlatformVersion: $(NetStandardPlatformVersion)"/>
         <Message Text="ToolsPackageVersion: $(ToolsPackageVersion)"/>
         <Message Text="AspNetCorePackageVersion: $(AspNetCorePackageVersion)"/>
+        <Message Text="ScaffoldingPackageVersion: $(ScaffoldingPackageVersion)"/>
     </Target>
     
     <Target Name="SetupPackageSource">
-        <GetPackageSource Condition="'$(PackageSource)' == '' and '$(SetupDrop)' != ''" SetupDrop="$(SetupDrop)">
+        <GetPackageSource Condition="'$(SetupPackageSource)' == '' and '$(SetupDrop)' != ''" SetupDrop="$(SetupDrop)">
             <Output PropertyName="SetupPackageSource" TaskParameter="PackageSource"/>
         </GetPackageSource>
         <PropertyGroup>
@@ -141,7 +149,7 @@
         <Message Text="PackageSourceFoRestore: $(PackageSourceForRestore)"/>
     </Target>
 
-    <Target Name="CopyPackagesForBuild" DependsOnTargets="SetupPackageSource" Condition="'$(SetupDrop)' != '' and '$(SkipCopyPackages)' == 'false'">
+    <Target Name="CopyPackagesForBuild" DependsOnTargets="SetupPackageSource" Condition="'$(SetupPackageSource)' != '' and '$(SkipCopyPackages)' == 'false'">
         <RemoveDir Directories="$(CoherencePackageSources)" />
         <MakeDir Directories="$(CoherencePackageSources)" />
 

--- a/src/BaseTemplates/BaseProjectTemplates.csproj
+++ b/src/BaseTemplates/BaseProjectTemplates.csproj
@@ -90,6 +90,8 @@
     <RegexReplace Files="@(FilesToReplace)" Find="__NetStandardSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(NetStandardSemanticVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__ToolsPackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ToolsPackageVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__ToolsSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ToolsSemanticVersion)" />
+    <RegexReplace Files="@(FilesToReplace)" Find="__ScaffoldingPackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ScaffoldingPackageVersion)" />
+    <RegexReplace Files="@(FilesToReplace)" Find="__ScaffoldingSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ScaffoldingSemanticVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__AspNetCorePackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(AspNetCorePackageVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__AspNetCoreSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(AspNetCoreSemanticVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__BundlerPackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(BundlerPackageVersion)" />
@@ -167,6 +169,8 @@
     <RegexReplace Files="@(FilesToReplace)" Find="__NetStandardSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(NetStandardSemanticVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__ToolsPackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ToolsPackageVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__ToolsSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ToolsSemanticVersion)" />
+    <RegexReplace Files="@(FilesToReplace)" Find="__ScaffoldingPackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ScaffoldingPackageVersion)" />
+    <RegexReplace Files="@(FilesToReplace)" Find="__ScaffoldingSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ScaffoldingSemanticVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__AspNetCorePackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(AspNetCorePackageVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__AspNetCoreSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(AspNetCoreSemanticVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__BundlerPackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(BundlerPackageVersion)" />

--- a/src/BaseTemplates/EmptyWeb/project.json
+++ b/src/BaseTemplates/EmptyWeb/project.json
@@ -7,7 +7,7 @@
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
     $if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.Extensions.Logging.Console": "1.0.0-*"
   },
 

--- a/src/BaseTemplates/StarterWeb/project.json
+++ b/src/BaseTemplates/StarterWeb/project.json
@@ -5,13 +5,14 @@
       "type": "platform"
     },$endif$
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
-    },$if$ ($aspnet_useplatformhandler$ == false)$else$
+    },
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/BaseTemplates/WebAPI/project.json
+++ b/src/BaseTemplates/WebAPI/project.json
@@ -4,9 +4,10 @@
       "version": "__NetCorePlatformVersion__",
       "type": "platform"
     },$endif$
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/StarterWeb/AI/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/project.json
@@ -11,15 +11,16 @@
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0-*",
     "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
-    },$if$ ($aspnet_useplatformhandler$ == false)$else$
+    },
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.1-*",
     "Microsoft.EntityFrameworkCore.SqlServer.Design": {
       "version": "__AspNetCorePackageVersion__",
       "type": "build"
@@ -37,11 +38,11 @@
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0-*",
     "Microsoft.VisualStudio.Web.BrowserLink.Loader": "__VSVER__.0-*",
     "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-      "version": "__ToolsPackageVersion__",
+      "version": "__ScaffoldingPackageVersion__",
       "type": "build"
     },
     "Microsoft.VisualStudio.Web.CodeGenerators.Mvc":  {
-      "version": "__ToolsPackageVersion__",
+      "version": "__ScaffoldingPackageVersion__",
       "type": "build"
     }
   },
@@ -53,7 +54,7 @@
     "Microsoft.EntityFrameworkCore.Tools": "__ToolsPackageVersion__",
     "Microsoft.Extensions.SecretManager.Tools": "__ToolsPackageVersion__",
     "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-      "version": "__ToolsPackageVersion__",
+      "version": "__ScaffoldingPackageVersion__",
       "imports": [
         "portable-net45+win8"
       ]

--- a/src/Rules/StarterWeb/AI/NoAuth/project.json
+++ b/src/Rules/StarterWeb/AI/NoAuth/project.json
@@ -6,13 +6,14 @@
     },$endif$
     "Microsoft.ApplicationInsights.AspNetCore": "__ApplicationInsightsPackageVersion__",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
-    },$if$ ($aspnet_useplatformhandler$ == false)$else$
+    },
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/Common/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/Common/project.json
@@ -10,13 +10,14 @@
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
-    },$if$ ($aspnet_useplatformhandler$ == false)$else$
+    },
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/Common/project.json
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/Common/project.json
@@ -10,13 +10,14 @@
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
-    },$if$ ($aspnet_useplatformhandler$ == false)$else$
+    },
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/StarterWeb/IndividualAuth/project.json
+++ b/src/Rules/StarterWeb/IndividualAuth/project.json
@@ -10,15 +10,16 @@
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0-*",
     "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
-    },$if$ ($aspnet_useplatformhandler$ == false)$else$
+    },
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.1-*",
     "Microsoft.EntityFrameworkCore.SqlServer.Design": {
       "version": "__AspNetCorePackageVersion__",
       "type": "build"
@@ -36,11 +37,11 @@
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0-*",
     "Microsoft.VisualStudio.Web.BrowserLink.Loader": "__VSVER__.0-*",
     "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-      "version": "__ToolsPackageVersion__",
+      "version": "__ScaffoldingPackageVersion__",
       "type": "build"
     },
     "Microsoft.VisualStudio.Web.CodeGenerators.Mvc": {
-      "version": "__ToolsPackageVersion__",
+      "version": "__ScaffoldingPackageVersion__",
       "type": "build"
     }
   },
@@ -52,7 +53,7 @@
     "Microsoft.EntityFrameworkCore.Tools": "__ToolsPackageVersion__",
     "Microsoft.Extensions.SecretManager.Tools": "__ToolsPackageVersion__",
     "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-      "version": "__ToolsPackageVersion__",
+      "version": "__ScaffoldingPackageVersion__",
       "imports": [
         "portable-net45+win8"
       ]

--- a/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Common/project.json
@@ -9,13 +9,14 @@
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
-    },$if$ ($aspnet_useplatformhandler$ == false)$else$
+    },
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/WebAPI/AI/NoAuth/project.json
+++ b/src/Rules/WebAPI/AI/NoAuth/project.json
@@ -5,9 +5,10 @@
       "type": "platform"
     },$endif$
     "Microsoft.ApplicationInsights.AspNetCore": "__ApplicationInsightsPackageVersion__",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/AI/OrganizationalAuth/Single/project.json
@@ -8,9 +8,10 @@
     },$endif$
     "Microsoft.ApplicationInsights.AspNetCore": "__ApplicationInsightsPackageVersion__",
     "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
+++ b/src/Rules/WebAPI/OrganizationalAuth/Single/project.json
@@ -7,9 +7,10 @@
       "type": "platform"
     },$endif$
     "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",$if$ ($aspnet_useplatformhandler$ == false)$else$
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",$endif$
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",

--- a/src/TemplateRules.csproj
+++ b/src/TemplateRules.csproj
@@ -232,6 +232,8 @@
     <RegexReplace Files="@(FilesToReplace)" Find="__NetStandardSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(NetStandardSemanticVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__ToolsPackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ToolsPackageVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__ToolsSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ToolsSemanticVersion)" />
+    <RegexReplace Files="@(FilesToReplace)" Find="__ScaffoldingPackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ScaffoldingPackageVersion)" />
+    <RegexReplace Files="@(FilesToReplace)" Find="__ScaffoldingSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(ScaffoldingSemanticVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__AspNetCorePackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(AspNetCorePackageVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__AspNetCoreSemanticVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(AspNetCoreSemanticVersion)" />
     <RegexReplace Files="@(FilesToReplace)" Find="__BundlerPackageVersion__" Condition="('%(Filename)%(Extension)' == 'project.json')" Encoding="ascii" Replace="$(BundlerPackageVersion)" />

--- a/src/project.json
+++ b/src/project.json
@@ -7,15 +7,16 @@
     "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0-*",
     "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc": "1.0.1-*",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "__ToolsPackageVersion__",
       "type": "build"
     },
+    "Microsoft.AspNetCore.Routing": "1.0.1-*",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.1-*",
     "Microsoft.EntityFrameworkCore.SqlServer.Design": {
       "version": "__AspNetCorePackageVersion__",
       "type": "build"
@@ -32,11 +33,11 @@
     "Microsoft.Extensions.Logging.Debug": "1.0.0-*",
     "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0-*",
     "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-      "version": "__ToolsPackageVersion__",
+      "version": "__ScaffoldingPackageVersion__",
       "type": "build"
     },
     "Microsoft.VisualStudio.Web.CodeGenerators.Mvc": {
-      "version": "__ToolsPackageVersion__",
+      "version": "__ScaffoldingPackageVersion__",
       "type": "build"
     }
   },
@@ -66,7 +67,7 @@
     "Microsoft.EntityFrameworkCore.Tools": "__ToolsPackageVersion__",
     "Microsoft.Extensions.SecretManager.Tools": "__ToolsPackageVersion__",
     "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-      "version": "__ToolsPackageVersion__",
+      "version": "__ScaffoldingPackageVersion__",
       "imports": [
         "portable-net45+win8"
       ]


### PR DESCRIPTION
….0.1 reference

//cc @muratg @rynowak @joeloff @divega @mlorbetske 

Attached is the closure project.json which will show the versions that the templates are using.

[project.json.txt](https://github.com/aspnet/Templates/files/448439/project.json.txt)
