### PR TITLE
Remove unused Microsoft.IdentityModel.Protocols.OpenIdConnect using s…

### DIFF
--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/NoRead/Startup.cs
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/NoRead/Startup.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
 namespace $safeprojectname$

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/NoRead/Startup.cs
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/NoRead/Startup.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace $safeprojectname$
 {

--- a/src/Rules/StarterWeb/OrganizationalAuth/Multiple/NoRead/Startup.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Multiple/NoRead/Startup.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
 namespace $safeprojectname$

--- a/src/Rules/StarterWeb/OrganizationalAuth/Single/NoRead/Startup.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Single/NoRead/Startup.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace $safeprojectname$
 {


### PR DESCRIPTION
…tatements

Still needed for the AD-Read versions of the templates since we use OpenIdConnectResponseType in those templates.

@mlorbetske @joeloff 
