### PR TITLE
Recommend HTTPS by a commented out attribute

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/AccountController.cs
@@ -16,6 +16,7 @@ using $safeprojectname$.Services;
 namespace $safeprojectname$.Controllers
 {
     [Authorize]
+    //[RequireHttps]
     public class AccountController : Controller
     {
         private readonly UserManager<ApplicationUser> _userManager;

--- a/src/Rules/StarterWeb/IndividualAuth/Controllers/ManageController.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Controllers/ManageController.cs
@@ -13,6 +13,7 @@ using $safeprojectname$.Services;
 namespace $safeprojectname$.Controllers
 {
     [Authorize]
+    //[RequireHttps]
     public class ManageController : Controller
     {
         private readonly UserManager<ApplicationUser> _userManager;


### PR DESCRIPTION
Using HTTPS is important for security.

We cannot set this attribute by default since the Visual Studio local web development environment is not configured to use HTTPS. But we can add a commented out attribute to encourage the developer to enable HTTPS for the Account and Manage controllers.
