### PR TITLE
Remove appsettings.{env.EnvironmentName}.json files

### DIFF
--- a/src/BaseTemplates/StarterWeb/Startup.cs
+++ b/src/BaseTemplates/StarterWeb/Startup.cs
@@ -17,7 +17,6 @@ namespace $safeprojectname$
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
             Configuration = builder.Build();
         }

--- a/src/BaseTemplates/WebAPI/Startup.cs
+++ b/src/BaseTemplates/WebAPI/Startup.cs
@@ -17,7 +17,6 @@ namespace $safeprojectname$
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
             Configuration = builder.Build();
         }

--- a/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/AI/IndividualAuth/Startup.cs
@@ -21,8 +21,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/AI/NoAuth/Startup.cs
+++ b/src/Rules/StarterWeb/AI/NoAuth/Startup.cs
@@ -17,7 +17,6 @@ namespace $safeprojectname$
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
 
             if (env.IsDevelopment())

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/NoRead/Startup.cs
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/NoRead/Startup.cs
@@ -19,8 +19,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/Read/Startup.cs
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Multiple/Read/Startup.cs
@@ -20,8 +20,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/NoRead/Startup.cs
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/NoRead/Startup.cs
@@ -17,8 +17,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/Read/Startup.cs
+++ b/src/Rules/StarterWeb/AI/OrganizationalAuth/Single/Read/Startup.cs
@@ -18,8 +18,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/IndividualAuth/Startup.cs
+++ b/src/Rules/StarterWeb/IndividualAuth/Startup.cs
@@ -21,8 +21,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/OrganizationalAuth/Multiple/NoRead/Startup.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Multiple/NoRead/Startup.cs
@@ -19,8 +19,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/OrganizationalAuth/Multiple/Read/Startup.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Multiple/Read/Startup.cs
@@ -20,8 +20,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/OrganizationalAuth/Single/NoRead/Startup.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Single/NoRead/Startup.cs
@@ -17,8 +17,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/StarterWeb/OrganizationalAuth/Single/Read/Startup.cs
+++ b/src/Rules/StarterWeb/OrganizationalAuth/Single/Read/Startup.cs
@@ -18,8 +18,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {

--- a/src/Rules/WebAPI/AI/NoAuth/Startup.cs
+++ b/src/Rules/WebAPI/AI/NoAuth/Startup.cs
@@ -16,8 +16,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsEnvironment("Development"))
             {

--- a/src/Rules/WebAPI/AI/OrganizationalAuth/Single/Startup.cs
+++ b/src/Rules/WebAPI/AI/OrganizationalAuth/Single/Startup.cs
@@ -16,8 +16,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsEnvironment("Development"))
             {

--- a/src/Rules/WebAPI/OrganizationalAuth/Single/Startup.cs
+++ b/src/Rules/WebAPI/OrganizationalAuth/Single/Startup.cs
@@ -16,8 +16,7 @@ namespace $safeprojectname$
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
             if (env.IsDevelopment())
             {


### PR DESCRIPTION
ASP.NET Core applications default to `Production` when there's no `ASPNETCORE_ENVIRONMENT` environment variable or `launchSettings.json` file. This has been done for security reasons to make sure, production environments don't show stack traces etc.

However, this also means people have to be careful that they don't get unintended side effects when they accidentally end up targeting the production environment. This could happen for various reasons, but the most obvious one might be that `dotnet run` does not honor the `launchSettings.json` file. If people don't set the environment variable on their PC, they could easily target Production when they switch between Visual Studio and dotnet cli.

Of course, people should not store sensitive data (e.g. connection strings) in these files, but even regular "app settings" could lead to unintended side effects (e.g. webhook URLs, ...)

There's also the scenario where people use certificates to get secrets from e.g. Azure Key Vault. In this case, the thumbprint isn't a secret and could be committed to source control. If the production certificate happens to end up on a developer's machine (this is a no-go but it could happen due to troubleshooting sessions etc.), "bad things" :tm: will happen.

Another aspect of this is that people who use IIS/IIS express don't see which environment they are targeting.

The best solution for this would be to make sure, production configs aren't in the same project. Instead, people should use environment variables, azure app settings, CI systems that merge the files on deployment, etc.

This PR would remove the active promotion of this feature. It would require people to make an active decision (and hopefully understand the advantages/disadvantages) if they wanted to keep using this workflow.

Concerns about defaulting to production have been raised in aspnet/hosting ( https://github.com/aspnet/Hosting/issues/863, https://github.com/aspnet/Hosting/pull/720 ), so I'm creating this PR as a discussion point based on @blowdart's and @muratg's feedback.
