### PR TITLE
Use IsDevelopment() instead of IsEnvironment("Development")

### DIFF
--- a/src/Rules/WebAPI/AI/NoAuth/Startup.cs
+++ b/src/Rules/WebAPI/AI/NoAuth/Startup.cs
@@ -19,7 +19,7 @@ namespace $safeprojectname$
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                 .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
 
-            if (env.IsEnvironment("Development"))
+            if (env.IsDevelopment())
             {
                 // This will push telemetry data through Application Insights pipeline faster, allowing you to view results immediately.
                 builder.AddApplicationInsightsSettings(developerMode: true);

--- a/src/Rules/WebAPI/AI/OrganizationalAuth/Single/Startup.cs
+++ b/src/Rules/WebAPI/AI/OrganizationalAuth/Single/Startup.cs
@@ -19,7 +19,7 @@ namespace $safeprojectname$
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                 .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
 
-            if (env.IsEnvironment("Development"))
+            if (env.IsDevelopment())
             {
                 // For more details on using the user secret store see https://go.microsoft.com/fwlink/?LinkID=532709
                 builder.AddUserSecrets();


### PR DESCRIPTION
All templates except these two use `env.IsDevelopment()` instead of `env.IsEnvironment("Development")`.
