### PR TITLE
Move Microsoft.NETCore.App package reference to proper place alphabet…

### DIFF
--- a/src/BaseTemplates/EmptyWeb/EmptyWeb.csproj
+++ b/src/BaseTemplates/EmptyWeb/EmptyWeb.csproj
@@ -17,12 +17,12 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>$endif$
 
-  <ItemGroup>$if$ ($context$ == WebCore)
-    <PackageReference Include="Microsoft.NETCore.App" Version="__NetCorePlatformVersion__" />$endif$
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="__AspNetCorePatchPackageVersion__" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="__AspNetCorePatchPackageVersion__" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="__AspNetCoreMvcPatchPackageVersion__" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="__AspNetCorePatchPackageVersion__" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="__AspNetCorePatchPackageVersion__" />$if$ ($context$ == WebCore)
+    <PackageReference Include="Microsoft.NETCore.App" Version="__NetCorePlatformVersion__" />$endif$
   </ItemGroup>
 
 $packagereferenceslist$

--- a/src/BaseTemplates/StarterWeb/StarterWeb.csproj
+++ b/src/BaseTemplates/StarterWeb/StarterWeb.csproj
@@ -21,8 +21,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>$endif$
 
-  <ItemGroup>$if$ ($context$ == WebCore)
-    <PackageReference Include="Microsoft.NETCore.App" Version="__NetCorePlatformVersion__" />$endif$
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="__AspNetCorePatchPackageVersion__" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="__AspNetCoreMvcPatchPackageVersion__" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="__AspNetCoreMvcPatchPackageVersion__" />
@@ -34,7 +33,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="__AspNetCorePatchPackageVersion__" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="__AspNetCorePatchPackageVersion__" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="__AspNetCorePatchPackageVersion__" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="__AspNetCorePatchPackageVersion__" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="__AspNetCorePatchPackageVersion__" />$if$ ($context$ == WebCore)
+    <PackageReference Include="Microsoft.NETCore.App" Version="__NetCorePlatformVersion__" />$endif$
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.0.1" />
   </ItemGroup>
 

--- a/src/BaseTemplates/WebAPI/WebAPI.csproj
+++ b/src/BaseTemplates/WebAPI/WebAPI.csproj
@@ -21,8 +21,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>$endif$
 
-  <ItemGroup>$if$ ($context$ == WebCore)
-    <PackageReference Include="Microsoft.NETCore.App" Version="__NetCorePlatformVersion__" />$endif$
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="__AspNetCoreMvcPatchPackageVersion__" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="__AspNetCoreMvcPatchPackageVersion__" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="__AspNetCorePatchPackageVersion__" />
@@ -33,7 +32,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="__AspNetCorePatchPackageVersion__" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="__AspNetCorePatchPackageVersion__" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="__AspNetCorePatchPackageVersion__" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="__AspNetCorePatchPackageVersion__" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="__AspNetCorePatchPackageVersion__" />$if$ ($context$ == WebCore)
+    <PackageReference Include="Microsoft.NETCore.App" Version="__NetCorePlatformVersion__" />$endif$
   </ItemGroup>
 
 $packagereferenceslist$


### PR DESCRIPTION
…ically.

This ensures that adding a package reference via VS UI results in the package refeerence being inserted alphabetically with the out of box templates.

For https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=299290
