### PR TITLE
Remove .dnx/** glob pattern from .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 **/artifacts/**
 packages/**
 .nuget/**
-.dnx/**
 .build/**
 **/.vs/**
 *.user


### PR DESCRIPTION
The `.dnx/**` glob pattern was added to `.gitignore` in the following commit: https://github.com/aspnet/Templates/commit/c896871c2b0c9db1b64f046105f7fb8ba4e8d23a. Now that the `DNX_HOME` environment variable isn't being referenced in `Verify.tasks`, I see no need to keep this in the `.gitignore` file.