### PR TITLE
Remove old Project K reference

### DIFF
--- a/src/Templates.xml
+++ b/src/Templates.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<TemplateDefinition Name="ProjectK" Order="8000">
+<TemplateDefinition Name="NetCore" Order="8000">
   <UI>
     <Template Name="Empty" BaseTemplateID="Microsoft.NetCore.CSharp.EmptyWeb" Order="8010">
       <Icon>Resources\Empty.png</Icon>


### PR DESCRIPTION
The `Templates.xml` file's `Name` attribute still references Project K, which predates DNX. Replace it with "NetCore", which more accurately represents current state.