### PR TITLE
Set server GC on WebCore

### DIFF
--- a/src/BaseTemplates/EmptyWeb/runtimeconfig.template.json
+++ b/src/BaseTemplates/EmptyWeb/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+﻿{
+  "configProperties": {
+    "System.GC.Server": true
+  }
+}

--- a/src/TemplateRules.csproj
+++ b/src/TemplateRules.csproj
@@ -145,7 +145,8 @@
 
     <!-- Common Files -->
     <LooseFiles Include="
-              Rules\Common\app.config">
+              Rules\Common\app.config;
+              Rules\Common\runtimeconfig.template.json">
       <TargetName>$(Rules)</TargetName>
       <SearchPath>.\</SearchPath>
     </LooseFiles>

--- a/src/Templates.xml
+++ b/src/Templates.xml
@@ -131,6 +131,9 @@
         <ApplyRules>
             <RunRule RuleID="EmptyReferences" />
         </ApplyRules>
+        <ApplyRules Option="WebCore">
+            <RunRule RuleID="ApplyRuntimeConfig" />
+        </ApplyRules>
         <ApplyRules Option="WebCoreFullFramework">
             <RunRule RuleID="ApplyAppConfig" />
         </ApplyRules>
@@ -173,6 +176,9 @@
                     <RunRule RuleID="StarterWebOrganizationalAuthMultipleRead" />
               </ApplyRules>
         </ApplyRules>
+        <ApplyRules Option="WebCore">
+            <RunRule RuleID="ApplyRuntimeConfig" />
+        </ApplyRules>
         <ApplyRules Option="WebCoreFullFramework">
             <RunRule RuleID="ApplyAppConfig" />
         </ApplyRules>
@@ -199,6 +205,9 @@
               <ApplyRules Option="SSOR">
                     <RunRule RuleID="WebAPIOrganizationalAuthSingle" />
               </ApplyRules>
+        </ApplyRules>
+        <ApplyRules Option="WebCore">
+            <RunRule RuleID="ApplyRuntimeConfig" />
         </ApplyRules>
         <ApplyRules Option="WebCoreFullFramework">
             <RunRule RuleID="ApplyAppConfig" />
@@ -305,6 +314,11 @@
       <!-- Apply app.config file for full FX -->
       <Rule ID="ApplyAppConfig">
           <AddFile Destination="app.config" Source="Rules\Common\app.config"/>
+      </Rule>
+
+      <!-- Apply runtimeconfig.template.json file for Core only -->
+      <Rule ID="ApplyRuntimeConfig">
+          <AddFile Destination="runtimeconfig.template.json" Source="Rules\Common\runtimeconfig.template.json"/>
       </Rule>
 
       <!-- Add Reference Rules - Empty Web -->


### PR DESCRIPTION
@mlorbetske @seancpeters @DamianEdwards 

Apply runtimeconfig.template.json to webcore projects to enable server GC.