### PR TITLE
Remove the ApplicationInsights.AspNetCore package redirection for 1.1

### DIFF
--- a/src/Templates.xml
+++ b/src/Templates.xml
@@ -389,7 +389,6 @@
   <Platforms Default="1.0">
     <Platform Version="1.0" Framework="netcoreapp1.0" />
     <Platform Version="1.1" Framework="netcoreapp1.1">
-      <Package Name="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0-beta1" />
       <Package Name="Microsoft.AspNetCore" Version="1.1.0" />
       <Package Name="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.0" />
       <Package Name="Microsoft.AspNetCore.Authentication.JwtBearer" Version="1.1.0"/>


### PR DESCRIPTION
The redirect was wrong, plus we never actually needed it as there is no 1.1 specific version of this package

@mlorbetske @joeloff 