### PR TITLE
Remove Razor View Compilation

### DIFF
--- a/src/BaseTemplates/StarterWeb/StarterWeb.csproj
+++ b/src/BaseTemplates/StarterWeb/StarterWeb.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$netframeworkversion$</TargetFramework>$if$ ($context$ == WebCoreFullFramework)
-    <RuntimeIdentifier>win7-x86</RuntimeIdentifier>$endif$$if$ ($platformversion$ == 1.1)
-    <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>$endif$
+    <RuntimeIdentifier>win7-x86</RuntimeIdentifier>$endif$
   </PropertyGroup>$if$ ($context$ == WebCore)
 
   <PropertyGroup>

--- a/src/Closure/Core11.csproj
+++ b/src/Closure/Core11.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="__NetCore11PlatformVersion__" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="__ApplicationInsightsPackageVersion__"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="__Mvc11PackageVersion__" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="1.1.0-msbuild3-update1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="__NetCore11PlatformVersion__" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="__NetCore11PlatformVersion__" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="__NetCore11PlatformVersion__" />

--- a/src/Closure/Core11Full.csproj
+++ b/src/Closure/Core11Full.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="__NetCore11PlatformVersion__" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="__ApplicationInsightsPackageVersion__"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="__Mvc11PackageVersion__" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="1.1.0-msbuild3-update1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="__NetCore11PlatformVersion__" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="__NetCore11PlatformVersion__" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="__NetCore11PlatformVersion__" />

--- a/src/Templates.xml
+++ b/src/Templates.xml
@@ -321,7 +321,6 @@
           <AddReference Name="Microsoft.ApplicationInsights.AspNetCore" Version="__ApplicationInsightsPackageVersion__"/>
           <AddReference Name="Microsoft.AspNetCore" Version="__NetCore10PlatformVersion__"/>
           <AddReference Name="Microsoft.AspNetCore.Mvc" Version="__AspNetCoreMvcPatchPackageVersion__"/>
-          <AddReference Name="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="1.1.0-msbuild3-update1" PrivateAssets="All" AppliesTo="1.1" />
           <AddReference Name="Microsoft.AspNetCore.StaticFiles" Version="__AspNetCorePatchPackageVersion__"/>
           <AddReference Name="Microsoft.Extensions.Logging.Debug" Version="__AspNetCorePatchPackageVersion__"/>
           <AddReference Name="Microsoft.VisualStudio.Web.BrowserLink" Version="__BrowserLinkPackageVersion__" AppliesTo="1.0"/>
@@ -336,7 +335,6 @@
           <AddReference Name="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="__AspNetCorePatchPackageVersion__"/>
           <AddReference Name="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="__AspNetCorePatchPackageVersion__"/>
           <AddReference Name="Microsoft.AspNetCore.Mvc" Version="__AspNetCoreMvcPatchPackageVersion__"/>
-          <AddReference Name="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="1.1.0-msbuild3-update1" PrivateAssets="All" AppliesTo="1.1" />
           <AddReference Name="Microsoft.AspNetCore.StaticFiles" Version="__AspNetCorePatchPackageVersion__"/>
           <AddReference Name="Microsoft.EntityFrameworkCore.Design" Version="__AspNetCoreMvcPatchPackageVersion__" PrivateAssets="All" />
           <AddReference Name="Microsoft.EntityFrameworkCore.SqlServer" Version="__AspNetCoreMvcPatchPackageVersion__"/>
@@ -358,7 +356,6 @@
           <AddReference Name="Microsoft.AspNetCore.Authentication.Cookies" Version="__AspNetCorePatchPackageVersion__"/>
           <AddReference Name="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="__AspNetCorePatchPackageVersion__"/>
           <AddReference Name="Microsoft.AspNetCore.Mvc" Version="__AspNetCoreMvcPatchPackageVersion__"/>
-          <AddReference Name="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="1.1.0-msbuild3-update1" PrivateAssets="All" AppliesTo="1.1" />
           <AddReference Name="Microsoft.AspNetCore.StaticFiles" Version="__AspNetCorePatchPackageVersion__"/>
           <AddReference Name="Microsoft.Extensions.Configuration.UserSecrets" Version="__AspNetCorePatchPackageVersion__"/>
           <AddReference Name="Microsoft.Extensions.Logging.Debug" Version="__AspNetCorePatchPackageVersion__"/>


### PR DESCRIPTION
@seancpeters @mlorbetske 

Sean, ignore the Core11*.csproj changes when you port to CLI, those are only used to test the template closure in regards to the Local Feed.