### PR TITLE
Clarify password reset sentence in ForgotPassword view

### DIFF
--- a/src/Rules/StarterWeb/IndividualAuth/Views/Account/ForgotPassword.cshtml
+++ b/src/Rules/StarterWeb/IndividualAuth/Views/Account/ForgotPassword.cshtml
@@ -5,7 +5,7 @@
 
 <h2>@ViewData["Title"]</h2>
 <p>
-    For more information on how to enable reset password please see this <a href="https://go.microsoft.com/fwlink/?LinkID=532713">article</a>.
+    For more information on how to enable password reset, please see this <a href="https://go.microsoft.com/fwlink/?LinkID=532713">article</a>.
 </p>
 
 @*<form asp-controller="Account" asp-action="ForgotPassword" method="post" class="form-horizontal">


### PR DESCRIPTION
The `ForgotPassword.cshtml` view includes a sentence which was missing a comma and reversed the words "reset" and "password".

/cc: @phenning @mlorbetske 