### PR TITLE
Change Lockout wording of comment

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Account/Login.cshtml.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Account/Login.cshtml.cs
@@ -68,8 +68,8 @@ namespace Company.WebApplication1.Pages.Account
 
             if (ModelState.IsValid)
             {
-                // This doesn't count login failures towards account lockout
-                // To enable password failures to trigger account lockout, set lockoutOnFailure: true
+                // This does count login failures towards account lockout
+                // To disable password failures to trigger account lockout, set lockoutOnFailure: false
                 var result = await _signInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: true);
                 if (result.Succeeded)
                 {


### PR DESCRIPTION
The Razor Pages Identity template turns on Lockout by default, unlike the MVC one.  This comment is left over from the MVC one and it no longer lines up with what is configured in the template.  I've reworded it to be accurate.  I can change it to just remove the comment all together if you want.